### PR TITLE
C51-278: Case duration custom field

### DIFF
--- a/CRM/Civicaseextras/CaseDurationLog.php
+++ b/CRM/Civicaseextras/CaseDurationLog.php
@@ -46,7 +46,7 @@ class CRM_CiviCaseextras_CaseDurationLog {
     ));
 
     foreach ($statuses['values'] as $status) {
-      $this->statuses[] = $status;
+      $this->statuses[$status['value']] = $status;
       $this->statusGroupingsPerLabel[$status['label']] = $status['grouping'];
     }
 
@@ -89,7 +89,7 @@ class CRM_CiviCaseextras_CaseDurationLog {
       !empty($params['case_status_id']) &&
       !empty($params['case_id'])
     ) {
-      $this->pendingCases['case_id'] = $params;
+      $this->pendingCases[$params['case_id']] = $params;
     }
   }
 
@@ -106,6 +106,8 @@ class CRM_CiviCaseextras_CaseDurationLog {
     } elseif($this->isCaseClosing($activityDAO)) {
       $this->endLog($activityDAO->id, $activityDAO->activity_date_time, $activityDAO->case_id);
     }
+
+    $this->calculateCaseDuration($activityDAO->case_id);
   }
 
   /**

--- a/CRM/Civicaseextras/CaseDurationLog.php
+++ b/CRM/Civicaseextras/CaseDurationLog.php
@@ -1,0 +1,386 @@
+<?php
+
+/**
+ * Handles the case duration log used to calculate total case durations.
+ */
+class CRM_CiviCaseextras_CaseDurationLog {
+
+  /**
+   * @var array
+   */
+  private $statuses = array();
+
+  /**
+   * Array mapping available case statuses to either Opened or Closed groupings.
+   *
+   * @var array
+   */
+  private $statusGroupingsPerLabel = array();
+
+  /**
+   * Array mapping activity type id's to ther names.
+   *
+   * @var array
+   */
+  private $activityTypes = array();
+
+  /**
+   * Array of cases that have been preprocessed, to be resolved once activity is
+   * saved.
+   *
+   * @var array
+   */
+  private $pendingCases = array();
+
+  /**
+   * Singleton.
+   *
+   * @var CRM_CiviCaseextras_CaseDurationLog
+   */
+  private static $singleton;
+
+  public function __construct() {
+    $statuses = civicrm_api3('OptionValue', 'get', array(
+      'sequential' => 1,
+      'option_group_id' => 'case_status',
+    ));
+
+    foreach ($statuses['values'] as $status) {
+      $this->statuses[] = $status;
+      $this->statusGroupingsPerLabel[$status['label']] = $status['grouping'];
+    }
+
+    $activityTypes = civicrm_api3('OptionValue', 'get', array(
+      'sequential' => 1,
+      'option_group_id' => 'activity_type',
+    ));
+
+    foreach ($activityTypes['values'] as $type) {
+      $this->activityTypes[$type['value']] = $type['name'];
+    }
+  }
+
+  /**
+   * Provides single object to handle all case and activity processing.
+   *
+   * @return \CRM_CiviCaseextras_CaseDurationLog
+   */
+  public static function singleton() {
+    if (self::$singleton === NULL) {
+      self::$singleton = new CRM_CiviCaseextras_CaseDurationLog();
+    }
+
+    return self::$singleton;
+  }
+
+  /**
+   * Preprocesses a case activity creation event and stores its data to be
+   * be handled once the activity is actually sored in the database and we have
+   * an ID for it.
+   *
+   * @param array $params
+   *   List of parameters being used to store the new activity
+   */
+  public function preProcessCaseActivity(&$params) {
+    $activityType = CRM_Utils_Array::value($params['activity_type_id'], $this->activityTypes);
+
+    if ($activityType === 'Change Case Status' &&
+      !empty($params['activity_date_time']) &&
+      !empty($params['case_status_id']) &&
+      !empty($params['case_id'])
+    ) {
+      $this->pendingCases['case_id'] = $params;
+    }
+  }
+
+  /**
+   * Processes a case's activity after it hs been stored in DB, to check if it
+   * was used to wither open or close a case and affect the case's duration log
+   * accordingly.
+   *
+   * @param CRM_Core_DAO $activityDAO
+   */
+  public function postProcessCaseActivity($activityDAO) {
+    if ($this->isCaseOpening($activityDAO)) {
+      $this->startLog($activityDAO->id, $activityDAO->activity_date_time, $activityDAO->case_id);
+    } elseif($this->isCaseClosing($activityDAO)) {
+      $this->endLog($activityDAO->id, $activityDAO->activity_date_time, $activityDAO->case_id);
+    }
+  }
+
+  /**
+   * Checks if the case associated to the activity is being opened.
+   *
+   * @param CRM_Core_DAO $activityDAO
+   *
+   * @return bool
+   */
+  private function isCaseOpening($activityDAO) {
+    $openCase = FALSE;
+    $activityType = CRM_Utils_Array::value($activityDAO->activity_type_id, $this->activityTypes);
+
+    if ($activityType === 'Open Case') {
+      $openCase = TRUE;
+    }
+    elseif ($activityType === 'Change Case Status' && isset($this->pendingCases[$activityDAO->case_id])) {
+      $caseStatusID = $this->pendingCases[$activityDAO->case_id]['case_status_id'];
+
+      if ($this->statuses[$caseStatusID]['grouping'] === 'Opened') {
+        $openCase = TRUE;
+      }
+    }
+
+    if ($openCase) {
+      $query = "
+        SELECT *
+        FROM civicrm_case_duration_log
+        WHERE case_id = %1
+        AND end_task IS NULL
+      ";
+      $dbResult = CRM_Core_DAO::executeQuery($query, array(
+        1 => array($activityDAO->case_id, 'Integer')
+      ));
+
+      if ($dbResult->N === 0) {
+        return TRUE;
+      }
+    }
+
+    return FALSE;
+  }
+
+  /**
+   * Determines if the case for the activity is closing.
+   *
+   * @param CRM_Core_DAO $activityDAO
+   *
+   * @return bool
+   */
+  private function isCaseClosing($activityDAO) {
+    $activityType = CRM_Utils_Array::value($activityDAO->activity_type_id, $this->activityTypes);
+
+    if ($activityType === 'Change Case Status') {
+      $caseStatusID = $this->pendingCases[$activityDAO->case_id]['case_status_id'];
+
+      if ($this->statuses[$caseStatusID]['grouping'] === 'Closed') {
+        return TRUE;
+      }
+    }
+
+    return FALSE;
+  }
+
+  /**
+   * Processes the provided activity, checking if it corresponds to any change
+   * in case status, to create the case duration log.
+   *
+   * @param CRM_Core_DAO $activityDAO
+   */
+  public function processOldCaseActivity($activityDAO) {
+    if ($this->wasCaseOpening($activityDAO)) {
+      $this->startLog($activityDAO->id, $activityDAO->activity_date_time, $activityDAO->case_id);
+    } elseif ($this->wasCaseClosing($activityDAO)) {
+      $this->endLog($activityDAO->id, $activityDAO->activity_date_time, $activityDAO->case_id);
+    }
+  }
+
+  /**
+   * Creates a new record to store the cases duration.
+   *
+   * @param $activityID
+   * @param $startDate
+   * @param $caseID
+   */
+  private function startLog($activityID, $startDate, $caseID) {
+    $query = "
+      INSERT INTO civicrm_case_duration_log(case_id, start_task, start_date)
+      VALUES (%1, %2, %3)
+    ";
+    $params = array(
+      1 => array($caseID, 'Integer'),
+      2 => array($activityID, 'Integer'),
+      3 => array($startDate, 'String'),
+    );
+    CRM_Core_DAO::executeQuery($query, $params);
+  }
+
+  /**
+   * Ends an open case log by seting end task, end date and calculating
+   * duration.
+   *
+   * @param $activityID
+   * @param $endDate
+   * @param $caseID
+   */
+  private function endLog($activityID, $endDate, $caseID) {
+    $query = "
+      UPDATE civicrm_case_duration_log
+      SET end_task = %1, end_date = %2, duration = datediff(end_date, start_date)
+      WHERE case_id = %3
+      AND end_task IS NULL
+    ";
+    $params = array(
+      1 => array($activityID, 'Integer'),
+      2 => array($endDate, 'String'),
+      3 => array($caseID, 'Integer'),
+    );
+    CRM_Core_DAO::executeQuery($query, $params);
+  }
+
+  /**
+   * Uses data of the provided case activity object to check if the case is
+   * being opened.
+   *
+   * @param CRM_Core_DAO $caseActivity
+   *   Object with the data for the case and activity.
+   *
+   * @return bool
+   *   True if the current activity is opening the case, false otherwise
+   */
+  private function wasCaseOpening($caseActivity) {
+    $changeStatusToOpen = FALSE;
+    $activityType = CRM_Utils_Array::value($caseActivity->activity_type_id, $this->activityTypes);
+
+    if ($activityType === 'Change Case Status') {
+      if ($this->extractStatusFromSubject($caseActivity->subject) === 'Opened') {
+        $changeStatusToOpen = TRUE;
+      }
+    }
+
+    if ($activityType === 'Open Case' || $changeStatusToOpen) {
+      $query = "
+        SELECT *
+        FROM civicrm_case_duration_log
+        WHERE case_id = %1
+        AND end_task IS NULL
+      ";
+      $dbResult = CRM_Core_DAO::executeQuery($query, array(
+        1 => array($caseActivity->case_id, 'Integer')
+      ));
+
+      if ($dbResult->N === 0) {
+        return TRUE;
+      }
+    }
+
+    return FALSE;
+  }
+
+  /**
+   * Checks if the given case activity is closing the case.
+   *
+   * @param CRM_Core_DAO $caseActivity
+   *   Object with the data for the case and activity.
+   *
+   * @return bool
+   *   True if the current activity is closing the case, false otherwise
+   */
+  private function wasCaseClosing($caseActivity) {
+    $activityType = CRM_Utils_Array::value($caseActivity->activity_type_id, $this->activityTypes);
+
+    if ($activityType === 'Change Case Status') {
+      if ($this->extractStatusFromSubject($caseActivity->subject) === 'Closed') {
+        return TRUE;
+      }
+    }
+
+    return FALSE;
+  }
+
+  /**
+   * Given an activity's subject, it tries to extract from the new case status,
+   * if it was opened or closed.
+   *
+   * @param string $activitySubject
+   *
+   * @return string|null
+   *   Returns 'Opened' or 'Closed' if it is able to extract the case status from
+   *   the subject. Otherwise it returns null.
+   */
+  private function extractStatusFromSubject($activitySubject) {
+    if (stripos($activitySubject, 'Case status changed from') !== FALSE) {
+      $subjectData = explode(' ', $activitySubject);
+      $newCaseStatus = $subjectData[sizeof($subjectData) - 1];
+
+      if (isset($this->statusGroupingsPerLabel[$newCaseStatus])) {
+        return $this->statusGroupingsPerLabel[$newCaseStatus];
+      }
+    }
+
+    return NULL;
+  }
+
+  /**
+   * Calculates the case's duration and stores it in the duration custom field.
+   *
+   * @param $caseID
+   */
+  public function calculateCaseDuration($caseID) {
+    $statsGroup = $this->getStatsGroup();
+    $durationField = $this->getDurationField($statsGroup);
+
+    $query = "
+      SELECT case_id, SUM(CASE WHEN duration IS NULL THEN datediff(CURDATE(), start_date) ELSE duration END) AS duration
+      FROM civicrm_case_duration_log
+      WHERE case_id = %1
+      GROUP BY case_id
+    ";
+    $params = array(1 => array($caseID, 'Integer'));
+    $durationResult = CRM_Core_DAO::executeQuery($query, $params);
+    $durationResult->fetch();
+
+    civicrm_api3('Case', 'create', array(
+      'custom_' . $durationField['id'] => $durationResult->duration,
+      'id' => 111,
+    ));
+  }
+
+  /**
+   * Calculates duration for all cases and stores it in the corresponding field.
+   */
+  public function calculateAllCasesDuration() {
+    $statsGroup = $this->getStatsGroup();
+    $durationField = $this->getDurationField($statsGroup);
+
+    CRM_Core_DAO::executeQuery('TRUNCATE TABLE ' . $statsGroup['table_name']);
+    CRM_Core_DAO::executeQuery("
+      INSERT INTO {$statsGroup['table_name']} (entity_id, {$durationField['column_name']})
+        SELECT case_id, SUM(CASE WHEN duration IS NULL THEN datediff(CURDATE(), start_date) ELSE duration END) AS duration
+        FROM civicrm_case_duration_log
+        GROUP BY case_id
+    ");
+  }
+
+  /**
+   * Obtains data for the custom group where case stats are stored.
+   *
+   * @return array
+   */
+  private function getStatsGroup() {
+    $customGroupResult = civicrm_api3('CustomGroup', 'get', array(
+      'sequential' => 1,
+      'name' => 'Case_Stats'
+    ));
+
+    return array_shift($customGroupResult['values']);
+  }
+
+  /**
+   * Obtains data for the custom field where duration is stored.
+   *
+   * @param array $customGroup
+   *   Array with the data for the custom group to which duration belongs.
+   *
+   * @return array
+   */
+  private function getDurationField($customGroup) {
+    $fieldResult = civicrm_api3('CustomField', 'get', array(
+      'sequential' => 1,
+      'custom_group_id' => $customGroup['id'],
+      'name' => 'duration',
+    ));
+
+    return array_shift($fieldResult['values']);
+  }
+
+}

--- a/CRM/Civicaseextras/CaseDurationLog.php
+++ b/CRM/Civicaseextras/CaseDurationLog.php
@@ -84,7 +84,7 @@ class CRM_CiviCaseextras_CaseDurationLog {
   public function preProcessCaseActivity(&$params) {
     $activityType = CRM_Utils_Array::value($params['activity_type_id'], $this->activityTypes);
 
-    if ($activityType === 'Change Case Status' &&
+    if ($activityType === CRM_Dictionaries_ActivityTypes::CHANGE_CASE_STATUS &&
       !empty($params['activity_date_time']) &&
       !empty($params['case_status_id']) &&
       !empty($params['case_id'])
@@ -121,13 +121,13 @@ class CRM_CiviCaseextras_CaseDurationLog {
     $openCase = FALSE;
     $activityType = CRM_Utils_Array::value($activityDAO->activity_type_id, $this->activityTypes);
 
-    if ($activityType === 'Open Case') {
+    if ($activityType === CRM_Dictionaries_ActivityTypes::OPEN_CASE) {
       $openCase = TRUE;
     }
-    elseif ($activityType === 'Change Case Status' && isset($this->pendingCases[$activityDAO->case_id])) {
+    elseif ($activityType === CRM_Dictionaries_ActivityTypes::CHANGE_CASE_STATUS && isset($this->pendingCases[$activityDAO->case_id])) {
       $caseStatusID = $this->pendingCases[$activityDAO->case_id]['case_status_id'];
 
-      if ($this->statuses[$caseStatusID]['grouping'] === 'Opened') {
+      if ($this->statuses[$caseStatusID]['grouping'] === CRM_Dictionaries_ActivityStatus::OPENED) {
         $openCase = TRUE;
       }
     }
@@ -161,10 +161,10 @@ class CRM_CiviCaseextras_CaseDurationLog {
   private function isCaseClosing($activityDAO) {
     $activityType = CRM_Utils_Array::value($activityDAO->activity_type_id, $this->activityTypes);
 
-    if ($activityType === 'Change Case Status') {
+    if ($activityType === CRM_Dictionaries_ActivityTypes::CHANGE_CASE_STATUS) {
       $caseStatusID = $this->pendingCases[$activityDAO->case_id]['case_status_id'];
 
-      if ($this->statuses[$caseStatusID]['grouping'] === 'Closed') {
+      if ($this->statuses[$caseStatusID]['grouping'] === CRM_Dictionaries_ActivityStatus::CLOSED) {
         return TRUE;
       }
     }
@@ -243,13 +243,13 @@ class CRM_CiviCaseextras_CaseDurationLog {
     $changeStatusToOpen = FALSE;
     $activityType = CRM_Utils_Array::value($caseActivity->activity_type_id, $this->activityTypes);
 
-    if ($activityType === 'Change Case Status') {
-      if ($this->extractStatusFromSubject($caseActivity->subject) === 'Opened') {
+    if ($activityType === CRM_Dictionaries_ActivityTypes::CHANGE_CASE_STATUS) {
+      if ($this->extractStatusFromSubject($caseActivity->subject) === CRM_Dictionaries_ActivityStatus::OPENED) {
         $changeStatusToOpen = TRUE;
       }
     }
 
-    if ($activityType === 'Open Case' || $changeStatusToOpen) {
+    if ($activityType === CRM_Dictionaries_ActivityTypes::OPEN_CASE || $changeStatusToOpen) {
       $query = "
         SELECT *
         FROM civicrm_case_duration_log
@@ -280,8 +280,8 @@ class CRM_CiviCaseextras_CaseDurationLog {
   private function wasCaseClosing($caseActivity) {
     $activityType = CRM_Utils_Array::value($caseActivity->activity_type_id, $this->activityTypes);
 
-    if ($activityType === 'Change Case Status') {
-      if ($this->extractStatusFromSubject($caseActivity->subject) === 'Closed') {
+    if ($activityType === CRM_Dictionaries_ActivityTypes::CHANGE_CASE_STATUS) {
+      if ($this->extractStatusFromSubject($caseActivity->subject) === CRM_Dictionaries_ActivityStatus::CLOSED) {
         return TRUE;
       }
     }

--- a/CRM/Civicaseextras/Dictionaries/ActivityStatus.php
+++ b/CRM/Civicaseextras/Dictionaries/ActivityStatus.php
@@ -1,0 +1,6 @@
+<?php
+
+class CRM_Dictionaries_ActivityStatus {
+  const CLOSED = 'Closed';
+  const OPENED = 'Opened';
+}

--- a/CRM/Civicaseextras/Dictionaries/ActivityTypes.php
+++ b/CRM/Civicaseextras/Dictionaries/ActivityTypes.php
@@ -1,0 +1,6 @@
+<?php
+
+class CRM_Dictionaries_ActivityTypes {
+  const CHANGE_CASE_STATUS = 'Change Case Status';
+  const OPEN_CASE = 'Open Case';
+}

--- a/CRM/Civicaseextras/Dictionaries/CaseStatus.php
+++ b/CRM/Civicaseextras/Dictionaries/CaseStatus.php
@@ -1,6 +1,6 @@
 <?php
 
-class CRM_Dictionaries_ActivityStatus {
+class CRM_Dictionaries_CaseStatus {
   const CLOSED = 'Closed';
   const OPENED = 'Opened';
 }

--- a/CRM/Civicaseextras/Services/ActivityTypesService.php
+++ b/CRM/Civicaseextras/Services/ActivityTypesService.php
@@ -1,0 +1,43 @@
+<?php
+
+class CRM_Civicaseextras_Services_ActivityTypesService {
+
+  /**
+   * @var array
+   *  list of activity type names indexed by their value.
+   */
+  protected $activityTypes;
+
+  /**
+   * Determines if the activity is of the expected type.
+   *
+   * @param array $activity
+   * @param string $expectedActivityType
+   */
+  public function isActivityOfGivenType($activity, $expectedActivityType) {
+    $this->populateActivityTypes();
+
+    $activityType = CRM_Utils_Array::value($activity['activity_type_id'], $this->activityTypes);
+
+    return $activityType === $expectedActivityType;
+  }
+
+  /**
+   * Populates the activities types property. The activity types will only be populated once.
+   */
+  protected function populateActivityTypes() {
+    if ($this->activityTypes) {
+      return;
+    }
+
+    $activityTypes = civicrm_api3('OptionValue', 'get', array(
+      'sequential' => 1,
+      'option_group_id' => 'activity_type',
+    ));
+
+    foreach ($activityTypes['values'] as $type) {
+      $this->activityTypes[$type['value']] = $type['name'];
+    }
+  }
+
+}

--- a/CRM/Civicaseextras/Services/CaseStatusService.php
+++ b/CRM/Civicaseextras/Services/CaseStatusService.php
@@ -1,0 +1,67 @@
+<?php
+
+class CRM_Civicaseextras_Services_CaseStatusService {
+  /**
+   * @var array
+   *  List of statuses indexed by their value.
+   */
+  protected $statuses = array();
+
+  /**
+   * @var array
+   *  List of statuses indexed by their label.
+   */
+  protected $statusIndexedByLabel = array();
+
+
+  /**
+   * Confirms that the given case has the expected status.
+   *
+   * @param array $case
+   * @param string $expectedStatus
+   * @return bool
+   */
+  public function confirmCaseStatus ($case, $expectedStatus) {
+    $this->populateStatuses();
+
+    $status = $this->statuses[$case['case_status_id']];
+
+    return $status['grouping'] === $expectedStatus;
+  }
+
+  /**
+   * Gets the case status object by its label property. If the status does not exist
+   * it returns NULL.
+   *
+   * @param string $statusLabel
+   * @return array
+   */
+  public function getStatusByLabel ($statusLabel) {
+    $this->populateStatuses();
+
+    if (isset($this->statusIndexedByLabel[$statusLabel])) {
+      return $this->statusIndexedByLabel[$statusLabel];
+    } else {
+      return NULL;
+    }
+  }
+
+  /**
+   * Populates the statuses and status indexed by label properties.
+   */
+  protected function populateStatuses() {
+    if ($this->statuses && $this->statusIndexedByLabel) {
+      return;
+    }
+
+    $statuses = civicrm_api3('OptionValue', 'get', array(
+      'sequential' => 1,
+      'option_group_id' => 'case_status',
+    ));
+
+    foreach ($statuses['values'] as $status) {
+      $this->statuses[$status['value']] = $status;
+      $this->statusIndexedByLabel[$status['label']] = $status['grouping'];
+    }
+  }
+}

--- a/CRM/Civicaseextras/Upgrader.php
+++ b/CRM/Civicaseextras/Upgrader.php
@@ -1,0 +1,609 @@
+<?php
+
+/**
+ * Collection of upgrade steps.
+ */
+class CRM_Civicaseextras_Upgrader extends CRM_Civicaseextras_Upgrader_Base {
+
+  // By convention, functions that look like "function upgrade_NNNN()" are
+  // upgrade tasks. They are executed in order (like Drupal's hook_update_N).
+
+  /**
+   * Tasks to perform when the module is installed.
+   */
+  public function install() {
+    CRM_Core_BAO_ConfigSetting::enableComponent('CiviCaseextras');
+
+    // Set activity categories
+    $categories = array(
+      'milestone' => array(
+        'Open Case',
+      ),
+      'communication' => array(
+        'Meeting',
+        'Phone Call',
+        'Email',
+        'SMS',
+        'Inbound Email',
+        'Follow up',
+        'Print PDF Letter',
+      ),
+      'system' => array(
+        'Change Case Type',
+        'Change Case Status',
+        'Change Case Subject',
+        'Change Custom Data',
+        'Change Case Start Date',
+        'Assign Case Role',
+        'Remove Case Role',
+        'Merge Case',
+        'Reassigned Case',
+        'Link Cases',
+        'Change Case Tags',
+        'Add Client To Case',
+      ),
+    );
+    foreach ($categories as $grouping => $activityTypes) {
+      civicrm_api3('OptionValue', 'get', array(
+        'return' => 'id',
+        'option_group_id' => 'activity_type',
+        'name' => array('IN' => $activityTypes),
+        'api.OptionValue.setvalue' => array(
+          'field' => 'grouping',
+          'value' => $grouping,
+        ),
+      ));
+    }
+
+    // Create activity types
+    $this->addOptionValue(array(
+      'option_group_id' => 'activity_type',
+      'label' => ts('Alert'),
+      'name' => 'Alert',
+      'grouping' => 'alert',
+      'is_reserved' => 0,
+      'description' => ts('Alerts to display in cases'),
+      'component_id' => 'CiviCaseextras',
+      'icon' => 'fa-exclamation',
+    ));
+    $this->addOptionValue(array(
+      'option_group_id' => 'activity_type',
+      'label' => ts('File Upload'),
+      'name' => 'File Upload',
+      // 'grouping' => '',
+      'is_reserved' => 0,
+      'description' => ts('Add files to a case'),
+      'component_id' => 'CiviCaseextras',
+      'icon' => 'fa-file',
+    ));
+    $this->addOptionValue(array(
+      'option_group_id' => 'activity_type',
+      'label' => ts('Remove Client From Case'),
+      'name' => 'Remove Client From Case',
+      'grouping' => 'system',
+      'is_reserved' => 0,
+      'description' => ts('Client removed from multi-client case'),
+      'component_id' => 'CiviCaseextras',
+      'icon' => 'fa-user-times',
+    ));
+
+    // Create activity statuses
+    $this->addOptionValue(array(
+      'option_group_id' => 'activity_status',
+      'label' => ts('Unread'),
+      'name' => 'Unread',
+      'grouping' => 'communication',
+      'is_reserved' => 0,
+      'color' => '#d9534f',
+    ));
+    $this->addOptionValue(array(
+      'option_group_id' => 'activity_status',
+      'label' => ts('Draft'),
+      'name' => 'Draft',
+      'grouping' => 'communication',
+      'is_reserved' => 0,
+      'color' => '#c2cfd8',
+    ));
+
+    // Set grouping for existing statuses
+    $allowedStatuses = array(
+      'Scheduled' => 'none,task,file,communication,milestone,system',
+      'Completed' => 'none,task,file,communication,milestone,alert,system',
+      'Cancelled' => 'none,communication,milestone,alert',
+      'Left Message' => 'none,communication,milestone',
+      'Unreachable' => 'none,communication,milestone',
+      'Not Required' => 'none,task,milestone',
+      'Available' => 'none,milestone',
+      'No_show' => 'none,milestone',
+    );
+    foreach ($allowedStatuses as $status => $grouping) {
+      civicrm_api3('OptionValue', 'get', array(
+        'option_group_id' => 'activity_status',
+        'name' => $status,
+        'return' => 'id',
+        'api.OptionValue.setvalue' => array(
+          'field' => 'grouping',
+          'value' => $grouping,
+        ),
+      ));
+    }
+
+    // Set status colors
+    $colors = array(
+      'activity_status' => array(
+        'Scheduled' => '#42afcb',
+        'Completed' => '#8ec68a',
+        'Left Message' => '#eca67f',
+        'Available' => '#5bc0de',
+      ),
+      'case_status' => array(
+        'Open' => '#42afcb',
+        'Closed' => '#4d5663',
+        'Urgent' => '#e6807f',
+      ),
+    );
+    foreach ($colors as $optionGroup => $statuses) {
+      foreach ($statuses as $status => $color) {
+        civicrm_api3('OptionValue', 'get', array(
+          'option_group_id' => $optionGroup,
+          'name' => $status,
+          'api.OptionValue.setvalue' => array(
+            'field' => 'color',
+            'value' => $color,
+          ),
+        ));
+      }
+    }
+
+    if (Civi::settings()->get('civicaseAllowMultipleClients') === 'default') {
+      Civi::settings()->set('civicaseAllowMultipleClients', '1');
+    }
+
+    if (!Civi::settings()->hasExplict('recordGeneratedLetters')) {
+      Civi::settings()->set('recordGeneratedLetters', 'combined-attached');
+    }
+
+    $this->createManageCasesMenuItem();
+  }
+
+  /**
+   * Creates 'Manage Cases' menu item for Cases navigation.
+   */
+  private function createManageCasesMenuItem() {
+    $this->addNav(array(
+      'label' => ts('Manage Cases', array('domain' => 'uk.co.compucorp.civicaseextras')),
+      'name' => 'Manage Cases',
+      'url' => 'civicrm/case/a/#/case/list',
+      'permission' => 'access my cases and activities,access all cases and activities',
+      'operator' => 'OR',
+      'separator' => 0,
+      'parent_name' => 'Cases',
+    ));
+
+    CRM_Core_BAO_Navigation::resetNavigation();
+
+    return TRUE;
+  }
+
+  /**
+   * Tasks to perform after the module is installed.
+   */
+  public function postInstall() {
+  }
+
+  /**
+   * Remove extension data when uninstalled.
+   */
+  public function uninstall() {
+    try {
+      civicrm_api3('OptionValue', 'get', array(
+        'return' => array('id'),
+        'option_group_id' => 'activity_category',
+        'options' => array('limit' => 0),
+        'api.OptionValue.delete' => array(),
+      ));
+    }
+    catch (Exception $e) {}
+    try {
+      civicrm_api3('OptionGroup', 'get', array(
+        'return' => array('id'),
+        'name' => 'activity_category',
+        'api.OptionGroup.delete' => array(),
+      ));
+    }
+    catch (Exception $e) {}
+    // Delete unused activity types
+    foreach (array('File', 'Alert') as $type) {
+      try {
+        $acts = civicrm_api3('Activity', 'getcount', array(
+          'activity_type_id' => $type,
+        ));
+        if (empty($acts['result'])) {
+          civicrm_api3('OptionValue', 'get', array(
+            'return' => array('id'),
+            'option_group_id' => 'activity_type',
+            'name' => $type,
+            'api.OptionValue.delete' => array(),
+          ));
+        }
+      }
+      catch (Exception $e) {}
+    }
+    // Delete unused activity statuses
+    foreach (array('Unread', 'Draft') as $status) {
+      try {
+        $acts = civicrm_api3('Activity', 'getcount', array(
+          'status_id' => $status,
+        ));
+        if (empty($acts['result'])) {
+          civicrm_api3('OptionValue', 'get', array(
+            'return' => array('id'),
+            'option_group_id' => 'activity_status',
+            'name' => $status,
+            'api.OptionValue.delete' => array(),
+          ));
+        }
+      }
+      catch (Exception $e) {}
+    }
+
+    $this->removeNav('Manage Cases');
+  }
+
+  /**
+   * Fixes original id of followup activities to point to the original activity and not a revision.
+   *
+   * TODO: This is a WIP (untested) and not yet called from anywhere.
+   * When it's ready we can change its name to upgrade_000X and call it from the installer
+   */
+  public function fixActivityRevisions() {
+    $sql = 'UPDATE civicrm_activity a, civicrm_activity b
+      SET a.parent_id = b.original_id
+      WHERE a.parent_id = b.id
+      AND b.original_id IS NOT NULL';
+    CRM_Core_DAO::executeQuery($sql);
+    // TODO: before we uncomment the below, need to migrate this history to advanced logging table
+    // CRM_Core_DAO::executeQuery('DELETE FROM civicrm_activity WHERE original_id IS NOT NULL');
+  }
+
+  /**
+   * Adds an option value if it doesn't already exist.
+   *
+   * Weight and value are calculated as needed.
+   *
+   * @param $params
+   */
+  protected function addOptionValue($params) {
+    $optionGroup = $params['option_group_id'];
+    $existing = civicrm_api3('OptionValue', 'get', array(
+      'option_group_id' => $optionGroup,
+      'name' => $params['name'],
+      'return' => 'id',
+      'options' => array('limit' => 1),
+    ));
+    if (!empty($existing['id'])) {
+      $params['id'] = $existing['id'];
+    }
+    else {
+      if (empty($params['value'])) {
+        $sql = "SELECT MAX(ROUND(value)) + 1 FROM civicrm_option_value WHERE option_group_id = (SELECT id FROM civicrm_option_group WHERE name = '$optionGroup')";
+        $params['value'] = CRM_Core_DAO::singleValueQuery($sql);
+      }
+      $sql = "SELECT MAX(ROUND(weight)) + 1 FROM civicrm_option_value WHERE option_group_id = (SELECT id FROM civicrm_option_group WHERE name = '$optionGroup')";
+      $params['weight'] = CRM_Core_DAO::singleValueQuery($sql);
+    }
+    civicrm_api3('OptionValue', 'create', $params);
+  }
+
+  /**
+   * @param array $menuItem
+   */
+  public function addNav($menuItem) {
+    $this->removeNav($menuItem['name']);
+
+    $menuItem['is_active'] = 1;
+    $menuItem['parent_id'] = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Navigation', $menuItem['parent_name'], 'id', 'name');
+    unset($menuItem['parent_name']);
+    CRM_Core_BAO_Navigation::add($menuItem);
+  }
+
+  /**
+   * @param string $name
+   *   The name of the item in `civicrm_navigation`.
+   */
+  protected function toggleNav($name, $isActive) {
+    CRM_Core_DAO::executeQuery("UPDATE `civicrm_navigation` SET is_active = %2 WHERE name IN (%1)", array(
+      1 => array($name, 'String'),
+      2 => array($isActive ? 1 : 0, 'Int'),
+    ));
+  }
+
+  /**
+   * @param string $name
+   *   The name of the item in `civicrm_navigation`.
+   */
+  protected function removeNav($name) {
+    CRM_Core_DAO::executeQuery("DELETE FROM `civicrm_navigation` WHERE name IN (%1)", array(
+      1 => array($name, 'String'),
+    ));
+  }
+
+  /**
+   * Re-enable the extension's parts.
+   */
+  public function enable() {
+    $this->swapCaseMenuItems();
+
+    $this->toggleNav('Manage Cases', TRUE);
+  }
+
+  /**
+   * Disable the extension's parts without removing them.
+   */
+  public function disable() {
+    $this->swapCaseMenuItems();
+
+    $this->toggleNav('Manage Cases', FALSE);
+  }
+
+  /**
+   * Swaps weight and has_separator values between 'Find Cases'
+   * and 'Manage Cases' menu items.
+   */
+  private function swapCaseMenuItems() {
+    $findCasesMenuItem = $this->getCaseMenuItem('Find Cases');
+    $manageCasesMenuItem = $this->getCaseMenuItem('Manage Cases');
+
+    if (!$findCasesMenuItem || !$manageCasesMenuItem) {
+      return TRUE;
+    }
+
+    // Updating 'Find Cases' menu item.
+    civicrm_api3('Navigation', 'create', array(
+      'id' => $findCasesMenuItem['id'],
+      'weight' => !empty($manageCasesMenuItem['weight']) ? $manageCasesMenuItem['weight'] : NULL,
+      'has_separator' => $manageCasesMenuItem['has_separator'],
+    ));
+
+    // Updating 'Manage Cases' menu item.
+    civicrm_api3('Navigation', 'create', array(
+      'id' => $manageCasesMenuItem['id'],
+      'weight' => !empty($findCasesMenuItem['weight']) ? $findCasesMenuItem['weight'] : NULL,
+      'has_separator' => $findCasesMenuItem['has_separator'],
+    ));
+
+    CRM_Core_BAO_Navigation::resetNavigation();
+  }
+
+  /**
+   * Returns an array containing Case menu item for specified name.
+   * Returns NULL if menu item is not found.
+   *
+   * @param string $name
+   *
+   * @return array|NULL
+   */
+  private function getCaseMenuItem($name) {
+    $result = civicrm_api3('Navigation', 'get', array(
+      'sequential' => 1,
+      'parent_id' => 'Cases',
+      'name' => $name,
+      'options' => array('limit' => 1),
+    ));
+
+    if (empty($result['id'])) {
+      return NULL;
+    }
+
+    return $result['values'][0];
+  }
+
+  /**
+   * Creates custom group for case stats and custom field to hold case duration.
+   *
+   * @return bool
+   */
+  public function upgrade_1001() {
+    $customGroup = $this->createStatsCustomGroup();
+    $durationField = $this->createDurationCustomField($customGroup);
+    $this->createCaseDurationLogTable();
+    $this->buildDurationLog();
+    $this->calculateCasesDuration($customGroup, $durationField);
+
+    return false;
+  }
+
+  /**
+   * Calculates duration for all cases and stores it in the corresponding field.
+   *
+   * @param $statsGroup
+   * @param $durationField
+   */
+  private function calculateCasesDuration($statsGroup, $durationField) {
+    CRM_Core_DAO::executeQuery('TRUNCATE TABLE ' . $statsGroup['table_name']);
+    CRM_Core_DAO::executeQuery("
+      INSERT INTO {$statsGroup['table_name']} (entity_id, {$durationField['column_name']})
+        SELECT case_id, SUM(CASE WHEN duration IS NULL THEN datediff(CURDATE(), start_date) ELSE duration END) AS duration
+        FROM civicrm_case_duration_log
+        GROUP BY case_id
+    ");
+  }
+
+  /**
+   * Inserts records into case duration log table by processing all cases'
+   * history.
+   */
+  private function buildDurationLog() {
+    CRM_Core_DAO::executeQuery('TRUNCATE TABLE civicrm_case_duration_log');
+
+    $query = "
+      SELECT civicrm_case_activity.case_id, civicrm_activity.*
+      FROM civicrm_case, civicrm_case_activity, civicrm_activity,
+        civicrm_option_group og_activity_type,
+        civicrm_option_value ov_activity_type
+      WHERE civicrm_case.id = civicrm_case_activity.case_id
+      AND civicrm_case_activity.activity_id = civicrm_activity.id
+      AND og_activity_type.name = 'activity_type'
+      AND og_activity_type.id = ov_activity_type.option_group_id
+      AND ov_activity_type.value = civicrm_activity.activity_type_id
+      AND ov_activity_type.name IN ('Open Case', 'Change Case Status')
+      ORDER BY civicrm_case.id ASC, civicrm_activity.activity_date_time
+    ";
+    $caseActivitiesResult = CRM_Core_DAO::executeQuery($query);
+
+    $logger = new CRM_CiviCaseextras_CaseDurationLog();
+    while ($caseActivitiesResult->fetch()) {
+      $logger->processOldCaseActivity($caseActivitiesResult);
+    }
+  }
+
+  /**
+   * Creates case duration log table.
+   */
+  private function createCaseDurationLogTable() {
+    CRM_Core_DAO::executeQuery("
+      CREATE TABLE IF NOT EXISTS `civicrm_case_duration_log` (
+        `id` int(10) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'Primary key.',
+        `case_id` int(10) UNSIGNED NOT NULL COMMENT 'Case ID for which the record is set.',
+        `start_task` int(10) UNSIGNED NOT NULL COMMENT 'Task that signaled the case''s start.',
+        `start_date` date NOT NULL COMMENT 'Date on which the case started.',
+        `end_task` int(10) UNSIGNED DEFAULT NULL COMMENT 'Task on which the case ended.',
+        `end_date` date DEFAULT NULL COMMENT 'Date on which the case ended.',
+        `duration` int(11) DEFAULT NULL COMMENT 'Case''s duration, in days.',
+
+        PRIMARY KEY (`id`),
+        KEY `case_id` (`case_id`),
+        KEY `fk_start_task` (`start_task`),
+        KEY `fk_end_task` (`end_task`),
+
+        CONSTRAINT `fk_end_task` FOREIGN KEY (`end_task`) REFERENCES `civicrm_activity` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+        CONSTRAINT `fk_case` FOREIGN KEY (`case_id`) REFERENCES `civicrm_case` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+        CONSTRAINT `fk_start_task` FOREIGN KEY (`start_task`) REFERENCES `civicrm_activity` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+      ) ENGINE=InnoDB;
+    ");
+  }
+
+  /**
+   * Creates a custom group for cases to put case stats.
+   *
+   * @return array
+   *   Data for the created/obtained custom group.
+   */
+  private function createStatsCustomGroup() {
+    $customGroupResult = civicrm_api3('CustomGroup', 'get', array(
+      'sequential' => 1,
+      'name' => 'Case_Stats'
+    ));
+
+    if ($customGroupResult['count'] < 1) {
+      $customGroupResult = civicrm_api3('CustomGroup', 'create', array(
+        'sequential' => 1,
+        'title' => 'Case Stats',
+        'name' => 'Case_Stats',
+        'extends' => 'Case',
+        'weight' => 10,
+        'collapse_display' => 0,
+        'style' => 'Inline',
+        'is_active' => 1
+      ));
+    }
+
+    return array_shift($customGroupResult['values']);
+  }
+
+  /**
+   * Create duration custom field on given custom group.
+   *
+   * @param array $customGroup
+   *   Data of the custom group where the field should be created
+   */
+  private function createDurationCustomField($customGroup) {
+    $fieldResult = civicrm_api3('CustomField', 'get', array(
+      'sequential' => 1,
+      'custom_group_id' => $customGroup['id'],
+      'name' => 'duration',
+    ));
+
+    if ($fieldResult['count'] < 1) {
+      $fieldResult = civicrm_api3('CustomField', 'create', array(
+        'custom_group_id' => $customGroup['id'],
+        'name' => 'duration',
+        'label' => 'Duration (days)',
+        'html_type' => 'Text',
+        'data_type' => 'Int',
+        'weight' => 1,
+        'is_required' => 0,
+        'is_searchable' => 1,
+        'is_active' => 1,
+        'is_view' => 1,
+        'is_search_range' => 1,
+      ));
+    }
+
+    return array_shift($fieldResult['values']);
+  }
+
+  /**
+   * Example: Run a couple simple queries.
+   *
+   * @return TRUE on success
+   * @throws Exception
+   *
+  public function upgrade_4200() {
+    $this->ctx->log->info('Applying update 4200');
+    CRM_Core_DAO::executeQuery('UPDATE foo SET bar = "whiz"');
+    CRM_Core_DAO::executeQuery('DELETE FROM bang WHERE willy = wonka(2)');
+    return TRUE;
+  } // */
+
+
+  /**
+   * Example: Run a slow upgrade process by breaking it up into smaller chunk.
+   *
+   * @return TRUE on success
+   * @throws Exception
+  public function upgrade_4202() {
+    $this->ctx->log->info('Planning update 4202'); // PEAR Log interface
+
+    $this->addTask(ts('Process first step'), 'processPart1', $arg1, $arg2);
+    $this->addTask(ts('Process second step'), 'processPart2', $arg3, $arg4);
+    $this->addTask(ts('Process second step'), 'processPart3', $arg5);
+    return TRUE;
+  }
+  public function processPart1($arg1, $arg2) { sleep(10); return TRUE; }
+  public function processPart2($arg3, $arg4) { sleep(10); return TRUE; }
+  public function processPart3($arg5) { sleep(10); return TRUE; }
+  // */
+
+
+  /**
+   * Example: Run an upgrade with a query that touches many (potentially
+   * millions) of records by breaking it up into smaller chunks.
+   *
+   * @return TRUE on success
+   * @throws Exception
+  public function upgrade_4203() {
+    $this->ctx->log->info('Planning update 4203'); // PEAR Log interface
+
+    $minId = CRM_Core_DAO::singleValueQuery('SELECT coalesce(min(id),0) FROM civicrm_contribution');
+    $maxId = CRM_Core_DAO::singleValueQuery('SELECT coalesce(max(id),0) FROM civicrm_contribution');
+    for ($startId = $minId; $startId <= $maxId; $startId += self::BATCH_SIZE) {
+      $endId = $startId + self::BATCH_SIZE - 1;
+      $title = ts('Upgrade Batch (%1 => %2)', array(
+        1 => $startId,
+        2 => $endId,
+      ));
+      $sql = '
+        UPDATE civicrm_contribution SET foobar = whiz(wonky()+wanker)
+        WHERE id BETWEEN %1 and %2
+      ';
+      $params = array(
+        1 => array($startId, 'Integer'),
+        2 => array($endId, 'Integer'),
+      );
+      $this->addTask($title, 'executeSql', $sql, $params);
+    }
+    return TRUE;
+  } // */
+
+}

--- a/CRM/Civicaseextras/Upgrader.php
+++ b/CRM/Civicaseextras/Upgrader.php
@@ -1,5 +1,7 @@
 <?php
 
+use CRM_CiviCaseextras_Services_ActivityTypesService as ActivityTypesService;
+
 /**
  * Collection of upgrade steps.
  */
@@ -428,7 +430,7 @@ class CRM_Civicaseextras_Upgrader extends CRM_Civicaseextras_Upgrader_Base {
       $dao = new CRM_Core_DAO_Job();
       $dao->domain_id = CRM_Core_Config::domainID();
       $dao->run_frequency = 'Daily';
-      $dao->parameters = null;
+      $dao->parameters = NULL;
       $dao->name = 'Case Duration Calculation';
       $dao->description = 'Job to update the duration of cases.';
       $dao->api_entity = 'case';
@@ -459,6 +461,8 @@ class CRM_Civicaseextras_Upgrader extends CRM_Civicaseextras_Upgrader_Base {
    * history.
    */
   private function buildDurationLog() {
+    $activityTypesService = new ActivityTypesService();
+
     CRM_Core_DAO::executeQuery('TRUNCATE TABLE civicrm_case_duration_log');
 
     $query = "
@@ -476,7 +480,8 @@ class CRM_Civicaseextras_Upgrader extends CRM_Civicaseextras_Upgrader_Base {
     ";
     $caseActivitiesResult = CRM_Core_DAO::executeQuery($query);
 
-    $logger = new CRM_CiviCaseextras_CaseDurationLog();
+    $logger = new CRM_CiviCaseextras_CaseDurationLog($activityTypesService);
+
     while ($caseActivitiesResult->fetch()) {
       $logger->processOldCaseActivity($caseActivitiesResult);
     }
@@ -517,7 +522,7 @@ class CRM_Civicaseextras_Upgrader extends CRM_Civicaseextras_Upgrader_Base {
   private function createStatsCustomGroup() {
     $customGroupResult = civicrm_api3('CustomGroup', 'get', array(
       'sequential' => 1,
-      'name' => 'Case_Stats'
+      'name' => 'Case_Stats',
     ));
 
     if ($customGroupResult['count'] < 1) {
@@ -529,7 +534,7 @@ class CRM_Civicaseextras_Upgrader extends CRM_Civicaseextras_Upgrader_Base {
         'weight' => 10,
         'collapse_display' => 0,
         'style' => 'Inline',
-        'is_active' => 1
+        'is_active' => 1,
       ));
     }
 

--- a/CRM/Civicaseextras/Upgrader.php
+++ b/CRM/Civicaseextras/Upgrader.php
@@ -409,8 +409,32 @@ class CRM_Civicaseextras_Upgrader extends CRM_Civicaseextras_Upgrader_Base {
     $this->createCaseDurationLogTable();
     $this->buildDurationLog();
     $this->calculateCasesDuration($customGroup, $durationField);
+    $this->createCaseDurationScheduledJob();
 
     return false;
+  }
+
+  /**
+   * Creates scheduled job that maintains cases' durations updated.
+   */
+  private function createCaseDurationScheduledJob() {
+    $dao = new CRM_Core_DAO_Job();
+    $dao->api_entity = 'case';
+    $dao->api_action = 'calculatealldurations';
+    $dao->find(TRUE);
+
+    if (!$dao->id) {
+      $dao = new CRM_Core_DAO_Job();
+      $dao->domain_id = CRM_Core_Config::domainID();
+      $dao->run_frequency = 'Daily';
+      $dao->parameters = null;
+      $dao->name = 'Case Duration Calculation';
+      $dao->description = 'Job to update the duration of cases.';
+      $dao->api_entity = 'case';
+      $dao->api_action = 'calculatealldurations';
+      $dao->is_active = 1;
+      $dao->save();
+    }
   }
 
   /**

--- a/CRM/Civicaseextras/Upgrader.php
+++ b/CRM/Civicaseextras/Upgrader.php
@@ -1,6 +1,6 @@
 <?php
 
-use CRM_CiviCaseextras_Services_ActivityTypesService as ActivityTypesService;
+use CRM_CiviCaseextras_CaseDurationLog as CaseDurationLog;
 
 /**
  * Collection of upgrade steps.
@@ -461,7 +461,6 @@ class CRM_Civicaseextras_Upgrader extends CRM_Civicaseextras_Upgrader_Base {
    * history.
    */
   private function buildDurationLog() {
-    $activityTypesService = new ActivityTypesService();
 
     CRM_Core_DAO::executeQuery('TRUNCATE TABLE civicrm_case_duration_log');
 
@@ -480,7 +479,7 @@ class CRM_Civicaseextras_Upgrader extends CRM_Civicaseextras_Upgrader_Base {
     ";
     $caseActivitiesResult = CRM_Core_DAO::executeQuery($query);
 
-    $logger = new CRM_CiviCaseextras_CaseDurationLog($activityTypesService);
+    $logger = CaseDurationLog::fabricate();
 
     while ($caseActivitiesResult->fetch()) {
       $logger->processOldCaseActivity($caseActivitiesResult);

--- a/CRM/Civicaseextras/Upgrader.php
+++ b/CRM/Civicaseextras/Upgrader.php
@@ -406,12 +406,13 @@ class CRM_Civicaseextras_Upgrader extends CRM_Civicaseextras_Upgrader_Base {
   public function upgrade_1001() {
     $customGroup = $this->createStatsCustomGroup();
     $durationField = $this->createDurationCustomField($customGroup);
+
     $this->createCaseDurationLogTable();
     $this->buildDurationLog();
     $this->calculateCasesDuration($customGroup, $durationField);
     $this->createCaseDurationScheduledJob();
 
-    return false;
+    return TRUE;
   }
 
   /**

--- a/CRM/Civicaseextras/Upgrader/Base.php
+++ b/CRM/Civicaseextras/Upgrader/Base.php
@@ -1,0 +1,376 @@
+<?php
+
+// AUTO-GENERATED FILE -- Civix may overwrite any changes made to this file
+use CRM_Civicaseextras_ExtensionUtil as E;
+
+/**
+ * Base class which provides helpers to execute upgrade logic
+ */
+class CRM_Civicaseextras_Upgrader_Base {
+
+  /**
+   * @var varies, subclass of this
+   */
+  static $instance;
+
+  /**
+   * @var CRM_Queue_TaskContext
+   */
+  protected $ctx;
+
+  /**
+   * @var string, eg 'com.example.myextension'
+   */
+  protected $extensionName;
+
+  /**
+   * @var string, full path to the extension's source tree
+   */
+  protected $extensionDir;
+
+  /**
+   * @var array(revisionNumber) sorted numerically
+   */
+  private $revisions;
+
+  /**
+   * @var boolean
+   *   Flag to clean up extension revision data in civicrm_setting
+   */
+  private $revisionStorageIsDeprecated = FALSE;
+
+  /**
+   * Obtain a reference to the active upgrade handler.
+   */
+  static public function instance() {
+    if (!self::$instance) {
+      // FIXME auto-generate
+      self::$instance = new CRM_Civicaseextras_Upgrader(
+        'uk.co.compucorp.civicaseextras',
+        realpath(__DIR__ . '/../../../')
+      );
+    }
+    return self::$instance;
+  }
+
+  /**
+   * Adapter that lets you add normal (non-static) member functions to the queue.
+   *
+   * Note: Each upgrader instance should only be associated with one
+   * task-context; otherwise, this will be non-reentrant.
+   *
+   * @code
+   * CRM_Civicaseextras_Upgrader_Base::_queueAdapter($ctx, 'methodName', 'arg1', 'arg2');
+   * @endcode
+   */
+  static public function _queueAdapter() {
+    $instance = self::instance();
+    $args = func_get_args();
+    $instance->ctx = array_shift($args);
+    $instance->queue = $instance->ctx->queue;
+    $method = array_shift($args);
+    return call_user_func_array(array($instance, $method), $args);
+  }
+
+  public function __construct($extensionName, $extensionDir) {
+    $this->extensionName = $extensionName;
+    $this->extensionDir = $extensionDir;
+  }
+
+  // ******** Task helpers ********
+
+  /**
+   * Run a CustomData file.
+   *
+   * @param string $relativePath the CustomData XML file path (relative to this extension's dir)
+   * @return bool
+   */
+  public function executeCustomDataFile($relativePath) {
+    $xml_file = $this->extensionDir . '/' . $relativePath;
+    return $this->executeCustomDataFileByAbsPath($xml_file);
+  }
+
+  /**
+   * Run a CustomData file
+   *
+   * @param string $xml_file  the CustomData XML file path (absolute path)
+   *
+   * @return bool
+   */
+  protected static function executeCustomDataFileByAbsPath($xml_file) {
+    $import = new CRM_Utils_Migrate_Import();
+    $import->run($xml_file);
+    return TRUE;
+  }
+
+  /**
+   * Run a SQL file.
+   *
+   * @param string $relativePath the SQL file path (relative to this extension's dir)
+   *
+   * @return bool
+   */
+  public function executeSqlFile($relativePath) {
+    CRM_Utils_File::sourceSQLFile(
+      CIVICRM_DSN,
+      $this->extensionDir . DIRECTORY_SEPARATOR . $relativePath
+    );
+    return TRUE;
+  }
+
+  /**
+   * @param string $tplFile
+   *   The SQL file path (relative to this extension's dir).
+   *   Ex: "sql/mydata.mysql.tpl".
+   * @return bool
+   */
+  public function executeSqlTemplate($tplFile) {
+    // Assign multilingual variable to Smarty.
+    $upgrade = new CRM_Upgrade_Form();
+
+    $tplFile = CRM_Utils_File::isAbsolute($tplFile) ? $tplFile : $this->extensionDir . DIRECTORY_SEPARATOR . $tplFile;
+    $smarty = CRM_Core_Smarty::singleton();
+    $smarty->assign('domainID', CRM_Core_Config::domainID());
+    CRM_Utils_File::sourceSQLFile(
+      CIVICRM_DSN, $smarty->fetch($tplFile), NULL, TRUE
+    );
+    return TRUE;
+  }
+
+  /**
+   * Run one SQL query.
+   *
+   * This is just a wrapper for CRM_Core_DAO::executeSql, but it
+   * provides syntatic sugar for queueing several tasks that
+   * run different queries
+   */
+  public function executeSql($query, $params = array()) {
+    // FIXME verify that we raise an exception on error
+    CRM_Core_DAO::executeQuery($query, $params);
+    return TRUE;
+  }
+
+  /**
+   * Syntatic sugar for enqueuing a task which calls a function in this class.
+   *
+   * The task is weighted so that it is processed
+   * as part of the currently-pending revision.
+   *
+   * After passing the $funcName, you can also pass parameters that will go to
+   * the function. Note that all params must be serializable.
+   */
+  public function addTask($title) {
+    $args = func_get_args();
+    $title = array_shift($args);
+    $task = new CRM_Queue_Task(
+      array(get_class($this), '_queueAdapter'),
+      $args,
+      $title
+    );
+    return $this->queue->createItem($task, array('weight' => -1));
+  }
+
+  // ******** Revision-tracking helpers ********
+
+  /**
+   * Determine if there are any pending revisions.
+   *
+   * @return bool
+   */
+  public function hasPendingRevisions() {
+    $revisions = $this->getRevisions();
+    $currentRevision = $this->getCurrentRevision();
+
+    if (empty($revisions)) {
+      return FALSE;
+    }
+    if (empty($currentRevision)) {
+      return TRUE;
+    }
+
+    return ($currentRevision < max($revisions));
+  }
+
+  /**
+   * Add any pending revisions to the queue.
+   */
+  public function enqueuePendingRevisions(CRM_Queue_Queue $queue) {
+    $this->queue = $queue;
+
+    $currentRevision = $this->getCurrentRevision();
+    foreach ($this->getRevisions() as $revision) {
+      if ($revision > $currentRevision) {
+        $title = ts('Upgrade %1 to revision %2', array(
+          1 => $this->extensionName,
+          2 => $revision,
+        ));
+
+        // note: don't use addTask() because it sets weight=-1
+
+        $task = new CRM_Queue_Task(
+          array(get_class($this), '_queueAdapter'),
+          array('upgrade_' . $revision),
+          $title
+        );
+        $this->queue->createItem($task);
+
+        $task = new CRM_Queue_Task(
+          array(get_class($this), '_queueAdapter'),
+          array('setCurrentRevision', $revision),
+          $title
+        );
+        $this->queue->createItem($task);
+      }
+    }
+  }
+
+  /**
+   * Get a list of revisions.
+   *
+   * @return array(revisionNumbers) sorted numerically
+   */
+  public function getRevisions() {
+    if (!is_array($this->revisions)) {
+      $this->revisions = array();
+
+      $clazz = new ReflectionClass(get_class($this));
+      $methods = $clazz->getMethods();
+      foreach ($methods as $method) {
+        if (preg_match('/^upgrade_(.*)/', $method->name, $matches)) {
+          $this->revisions[] = $matches[1];
+        }
+      }
+      sort($this->revisions, SORT_NUMERIC);
+    }
+
+    return $this->revisions;
+  }
+
+  public function getCurrentRevision() {
+    $revision = CRM_Core_BAO_Extension::getSchemaVersion($this->extensionName);
+    if (!$revision) {
+      $revision = $this->getCurrentRevisionDeprecated();
+    }
+    return $revision;
+  }
+
+  private function getCurrentRevisionDeprecated() {
+    $key = $this->extensionName . ':version';
+    if ($revision = CRM_Core_BAO_Setting::getItem('Extension', $key)) {
+      $this->revisionStorageIsDeprecated = TRUE;
+    }
+    return $revision;
+  }
+
+  public function setCurrentRevision($revision) {
+    CRM_Core_BAO_Extension::setSchemaVersion($this->extensionName, $revision);
+    // clean up legacy schema version store (CRM-19252)
+    $this->deleteDeprecatedRevision();
+    return TRUE;
+  }
+
+  private function deleteDeprecatedRevision() {
+    if ($this->revisionStorageIsDeprecated) {
+      $setting = new CRM_Core_BAO_Setting();
+      $setting->name = $this->extensionName . ':version';
+      $setting->delete();
+      CRM_Core_Error::debug_log_message("Migrated extension schema revision ID for {$this->extensionName} from civicrm_setting (deprecated) to civicrm_extension.\n");
+    }
+  }
+
+  // ******** Hook delegates ********
+
+  /**
+   * @see https://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_install
+   */
+  public function onInstall() {
+    $files = glob($this->extensionDir . '/sql/*_install.sql');
+    if (is_array($files)) {
+      foreach ($files as $file) {
+        CRM_Utils_File::sourceSQLFile(CIVICRM_DSN, $file);
+      }
+    }
+    $files = glob($this->extensionDir . '/sql/*_install.mysql.tpl');
+    if (is_array($files)) {
+      foreach ($files as $file) {
+        $this->executeSqlTemplate($file);
+      }
+    }
+    $files = glob($this->extensionDir . '/xml/*_install.xml');
+    if (is_array($files)) {
+      foreach ($files as $file) {
+        $this->executeCustomDataFileByAbsPath($file);
+      }
+    }
+    if (is_callable(array($this, 'install'))) {
+      $this->install();
+    }
+  }
+
+  /**
+   * @see https://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_postInstall
+   */
+  public function onPostInstall() {
+    $revisions = $this->getRevisions();
+    if (!empty($revisions)) {
+      $this->setCurrentRevision(max($revisions));
+    }
+    if (is_callable(array($this, 'postInstall'))) {
+      $this->postInstall();
+    }
+  }
+
+  /**
+   * @see https://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_uninstall
+   */
+  public function onUninstall() {
+    $files = glob($this->extensionDir . '/sql/*_uninstall.mysql.tpl');
+    if (is_array($files)) {
+      foreach ($files as $file) {
+        $this->executeSqlTemplate($file);
+      }
+    }
+    if (is_callable(array($this, 'uninstall'))) {
+      $this->uninstall();
+    }
+    $files = glob($this->extensionDir . '/sql/*_uninstall.sql');
+    if (is_array($files)) {
+      foreach ($files as $file) {
+        CRM_Utils_File::sourceSQLFile(CIVICRM_DSN, $file);
+      }
+    }
+  }
+
+  /**
+   * @see https://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_enable
+   */
+  public function onEnable() {
+    // stub for possible future use
+    if (is_callable(array($this, 'enable'))) {
+      $this->enable();
+    }
+  }
+
+  /**
+   * @see https://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_disable
+   */
+  public function onDisable() {
+    // stub for possible future use
+    if (is_callable(array($this, 'disable'))) {
+      $this->disable();
+    }
+  }
+
+  public function onUpgrade($op, CRM_Queue_Queue $queue = NULL) {
+    switch ($op) {
+      case 'check':
+        return array($this->hasPendingRevisions());
+
+      case 'enqueue':
+        return $this->enqueuePendingRevisions($queue);
+
+      default:
+    }
+  }
+
+}

--- a/api/v3/Case/Calculatealldurations.php
+++ b/api/v3/Case/Calculatealldurations.php
@@ -1,14 +1,12 @@
 <?php
 
-use CRM_CiviCaseextras_Services_ActivityTypesService as ActivityTypesService;
+use CRM_CiviCaseextras_CaseDurationLog as CaseDurationLog;
 
 /**
  * API call to calculate the duration of all cases.
  */
 function civicrm_api3_case_calculatealldurations() {
-  $activityTypesService = new ActivityTypesService();
-
-  $logger = new CRM_CiviCaseextras_CaseDurationLog($activityTypesService);
+  $logger = CaseDurationLog::fabricate();
   $logger->calculateAllCasesDuration();
 
   return array();

--- a/api/v3/Case/Calculatealldurations.php
+++ b/api/v3/Case/Calculatealldurations.php
@@ -1,10 +1,14 @@
 <?php
 
+use CRM_CiviCaseextras_Services_ActivityTypesService as ActivityTypesService;
+
 /**
  * API call to calculate the duration of all cases.
  */
 function civicrm_api3_case_calculatealldurations() {
-  $logger = new CRM_CiviCaseextras_CaseDurationLog();
+  $activityTypesService = new ActivityTypesService();
+
+  $logger = new CRM_CiviCaseextras_CaseDurationLog($activityTypesService);
   $logger->calculateAllCasesDuration();
 
   return array();

--- a/api/v3/Case/Calculatealldurations.php
+++ b/api/v3/Case/Calculatealldurations.php
@@ -1,0 +1,11 @@
+<?php
+
+/**
+ * API call to calculate the duration of all cases.
+ */
+function civicrm_api3_case_calculatealldurations() {
+  $logger = new CRM_Civicase_CaseDurationLog();
+  $logger->calculateAllCasesDuration();
+
+  return array();
+}

--- a/api/v3/Case/Calculatealldurations.php
+++ b/api/v3/Case/Calculatealldurations.php
@@ -4,7 +4,7 @@
  * API call to calculate the duration of all cases.
  */
 function civicrm_api3_case_calculatealldurations() {
-  $logger = new CRM_Civicase_CaseDurationLog();
+  $logger = new CRM_CiviCaseextras_CaseDurationLog();
   $logger->calculateAllCasesDuration();
 
   return array();

--- a/civicaseextras.php
+++ b/civicaseextras.php
@@ -1,6 +1,8 @@
 <?php
 
 require_once 'civicaseextras.civix.php';
+
+use CRM_CiviCaseextras_CaseDurationLog as CaseDurationLog;
 use CRM_Civicaseextras_ExtensionUtil as E;
 use CRM_Civicaseextras_Services_ActivityTypesService as ActivityTypesService;
 
@@ -144,8 +146,7 @@ function civicaseextras_civicrm_alterAngular(\Civi\Angular\Manager $angular) {
  */
 function civicaseextras_civicrm_pre($op, $objectName, $id, &$params) {
   if ($objectName === 'Activity' && $op == 'create') {
-    $activityTypesService = new ActivityTypesService();
-    $logger = new CRM_CiviCaseextras_CaseDurationLog($activityTypesService);
+    $logger = CaseDurationLog::fabricate();
 
     $logger->preProcessCaseActivity($params);
   }
@@ -156,8 +157,7 @@ function civicaseextras_civicrm_pre($op, $objectName, $id, &$params) {
  */
 function civicaseextras_civicrm_post($op, $objectName, $objectId, &$objectRef) {
   if ($objectName === 'Activity' && $op === 'create' && !empty($objectRef->case_id)) {
-    $activityTypesService = new ActivityTypesService();
-    $logger = new CRM_CiviCaseextras_CaseDurationLog($activityTypesService);
+    $logger = CaseDurationLog::fabricate();
 
     $logger->postProcessCaseActivity($objectRef);
   }

--- a/civicaseextras.php
+++ b/civicaseextras.php
@@ -138,6 +138,26 @@ function civicaseextras_civicrm_alterAngular(\Civi\Angular\Manager $angular) {
   _civicaseextras_civicrm_alterAngular($angular);
 }
 
+/**
+ * Implements hook_civicrm_pre().
+ */
+function civicaseextras_civicrm_pre($op, $objectName, $id, &$params) {
+  if ($objectName === 'Activity' && $op == 'create') {
+    $logger = CRM_Civicase_CaseDurationLog::singleton();
+    $logger->preProcessCaseActivity($params);
+  }
+}
+
+/**
+ * Implements hook_civicrm_post().
+ */
+function civicaseextras_civicrm_post($op, $objectName, $objectId, &$objectRef) {
+  if ($objectName === 'Activity' && $op === 'create' && !empty($objectRef->case_id)) {
+    $logger = CRM_Civicase_CaseDurationLog::singleton();
+    $logger->postProcessCaseActivity($objectRef);
+  }
+}
+
 // --- Functions below this ship commented out. Uncomment as required. ---
 
 /**

--- a/civicaseextras.php
+++ b/civicaseextras.php
@@ -2,6 +2,7 @@
 
 require_once 'civicaseextras.civix.php';
 use CRM_Civicaseextras_ExtensionUtil as E;
+use CRM_Civicaseextras_Services_ActivityTypesService as ActivityTypesService;
 
 /**
  * Implements hook_civicrm_config().
@@ -143,7 +144,9 @@ function civicaseextras_civicrm_alterAngular(\Civi\Angular\Manager $angular) {
  */
 function civicaseextras_civicrm_pre($op, $objectName, $id, &$params) {
   if ($objectName === 'Activity' && $op == 'create') {
-    $logger = new CRM_CiviCaseextras_CaseDurationLog();
+    $activityTypesService = new ActivityTypesService();
+    $logger = new CRM_CiviCaseextras_CaseDurationLog($activityTypesService);
+
     $logger->preProcessCaseActivity($params);
   }
 }
@@ -153,7 +156,9 @@ function civicaseextras_civicrm_pre($op, $objectName, $id, &$params) {
  */
 function civicaseextras_civicrm_post($op, $objectName, $objectId, &$objectRef) {
   if ($objectName === 'Activity' && $op === 'create' && !empty($objectRef->case_id)) {
-    $logger = new CRM_CiviCaseextras_CaseDurationLog();
+    $activityTypesService = new ActivityTypesService();
+    $logger = new CRM_CiviCaseextras_CaseDurationLog($activityTypesService);
+
     $logger->postProcessCaseActivity($objectRef);
   }
 }

--- a/civicaseextras.php
+++ b/civicaseextras.php
@@ -143,7 +143,7 @@ function civicaseextras_civicrm_alterAngular(\Civi\Angular\Manager $angular) {
  */
 function civicaseextras_civicrm_pre($op, $objectName, $id, &$params) {
   if ($objectName === 'Activity' && $op == 'create') {
-    $logger = CRM_Civicase_CaseDurationLog::singleton();
+    $logger = new CRM_CiviCaseextras_CaseDurationLog();
     $logger->preProcessCaseActivity($params);
   }
 }
@@ -153,7 +153,7 @@ function civicaseextras_civicrm_pre($op, $objectName, $id, &$params) {
  */
 function civicaseextras_civicrm_post($op, $objectName, $objectId, &$objectRef) {
   if ($objectName === 'Activity' && $op === 'create' && !empty($objectRef->case_id)) {
-    $logger = CRM_Civicase_CaseDurationLog::singleton();
+    $logger = new CRM_CiviCaseextras_CaseDurationLog();
     $logger->postProcessCaseActivity($objectRef);
   }
 }


### PR DESCRIPTION
## Overview

This PR allows cases to have a case duration field depending on how long it has been in an open state. It's important to note that this is not calculating the duration by simply checking the start and end date of the case, but by keeping track of when the case is closed and reopened.

For more information please refer to the original PR:
https://github.com/civicrm/org.civicrm.civicase/pull/98

## Technical details

The original PR was extracted and moved to this new extension as per requirements.

The solution was to create a custom table that keeps track of the case when a new activity is created or updated for it. It also runs a scheduled job to keep track of the cases duration.

A custom field is created for the case which stores the case duration so it can be easily accesible through the API.

Finally, a base upgrader class was generated using `civix` since this extension was missing it.