### PR TITLE
C51-281: Display case duration

### DIFF
--- a/CRM/Civicaseextras/APIWrappers/Case/Getcaselist.php
+++ b/CRM/Civicaseextras/APIWrappers/Case/Getcaselist.php
@@ -1,0 +1,35 @@
+<?php
+
+class CRM_Civicaseextras_APIWrappers_Case_Getcaselist implements API_Wrapper {
+    /**
+     * Implements API_Wrapper::fromApiInput().
+     *
+     * Alters the Case Getcaselist action so it includes the case duration custom field to the response.
+     *
+     * @param array $apiRequest
+     * @return array
+     */
+    public function fromApiInput($apiRequest) {
+      $return = CRM_Utils_Array::value('return', $apiRequest['params'], []);
+      $caseDuration = _civicaseextras_get_caseDurationField();
+
+      if ($caseDuration) {
+        $return[] = 'custom_' . $caseDuration['id'];
+      }
+
+      $apiRequest['params']['return'] = $return;
+
+      return $apiRequest;
+    }
+
+    /**
+     * Implements API_Wrapper::toApiOutput().
+     *
+     * @param array $apiRequest
+     * @param array $result
+     * @return array
+     */
+    public function toApiOutput($apiRequest, $result) {
+      return $result;
+    }
+  }

--- a/CRM/Civicaseextras/APIWrappers/Case/Getcaselist.php
+++ b/CRM/Civicaseextras/APIWrappers/Case/Getcaselist.php
@@ -1,42 +1,44 @@
 <?php
 
 class CRM_Civicaseextras_APIWrappers_Case_Getcaselist implements API_Wrapper {
-    /**
-     * {@inheritDoc} It Alters the Case Getcaselist action so it includes the case duration
-     * custom field to the response.
-     */
-    public function fromApiInput($apiRequest) {
-      if (!$this->shouldRun($apiRequest)) {
-        return $apiRequest;
-      }
 
-      $return = CRM_Utils_Array::value('return', $apiRequest['params'], []);
-      $caseDuration = _civicaseextras_get_caseDurationField();
-
-      if ($caseDuration) {
-        $return[] = 'custom_' . $caseDuration['id'];
-      }
-
-      $apiRequest['params']['return'] = $return;
-
+  /**
+   * {@inheritDoc} It Alters the Case Getcaselist action so it includes the case duration
+   * custom field to the response.
+   */
+  public function fromApiInput($apiRequest) {
+    if (!$this->shouldRun($apiRequest)) {
       return $apiRequest;
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function toApiOutput($apiRequest, $result) {
-      return $result;
+    $return = CRM_Utils_Array::value('return', $apiRequest['params'], []);
+    $caseDuration = _civicaseextras_get_caseDurationField();
+
+    if ($caseDuration) {
+      $return[] = 'custom_' . $caseDuration['id'];
     }
 
-    /**
-     * Determines if the API Wrapper should run by checking that the request is for
-     * the Case entity and the action is "getcaselist".
-     *
-     * @param array $apiRequest
-     * @return bool
-     */
-    public function shouldRun($apiRequest) {
-      return $apiRequest['entity'] === 'Case' && $apiRequest['action'] === 'getcaselist';
-    }
+    $apiRequest['params']['return'] = $return;
+
+    return $apiRequest;
   }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function toApiOutput($apiRequest, $result) {
+    return $result;
+  }
+
+  /**
+   * Determines if the API Wrapper should run by checking that the request is for
+   * the Case entity and the action is "getcaselist".
+   *
+   * @param array $apiRequest
+   * @return bool
+   */
+  public function shouldRun($apiRequest) {
+    return $apiRequest['entity'] === 'Case' && $apiRequest['action'] === 'getcaselist';
+  }
+
+}

--- a/CRM/Civicaseextras/APIWrappers/Case/Getcaselist.php
+++ b/CRM/Civicaseextras/APIWrappers/Case/Getcaselist.php
@@ -2,14 +2,14 @@
 
 class CRM_Civicaseextras_APIWrappers_Case_Getcaselist implements API_Wrapper {
     /**
-     * Implements API_Wrapper::fromApiInput().
-     *
-     * Alters the Case Getcaselist action so it includes the case duration custom field to the response.
-     *
-     * @param array $apiRequest
-     * @return array
+     * {@inheritDoc} It Alters the Case Getcaselist action so it includes the case duration
+     * custom field to the response.
      */
     public function fromApiInput($apiRequest) {
+      if (!$this->shouldRun($apiRequest)) {
+        return $apiRequest;
+      }
+
       $return = CRM_Utils_Array::value('return', $apiRequest['params'], []);
       $caseDuration = _civicaseextras_get_caseDurationField();
 
@@ -23,13 +23,20 @@ class CRM_Civicaseextras_APIWrappers_Case_Getcaselist implements API_Wrapper {
     }
 
     /**
-     * Implements API_Wrapper::toApiOutput().
-     *
-     * @param array $apiRequest
-     * @param array $result
-     * @return array
+     * {@inheritDoc}
      */
     public function toApiOutput($apiRequest, $result) {
       return $result;
+    }
+
+    /**
+     * Determines if the API Wrapper should run by checking that the request is for
+     * the Case entity and the action is "getcaselist".
+     *
+     * @param array $apiRequest
+     * @return bool
+     */
+    public function shouldRun($apiRequest) {
+      return $apiRequest['entity'] === 'Case' && $apiRequest['action'] === 'getcaselist';
     }
   }

--- a/CRM/Civicaseextras/APIWrappers/Case/Getcaselist.php
+++ b/CRM/Civicaseextras/APIWrappers/Case/Getcaselist.php
@@ -1,6 +1,21 @@
 <?php
 
+use CRM_Civicaseextras_Services_CustomValueService as CustomValueService;
+
 class CRM_Civicaseextras_APIWrappers_Case_Getcaselist implements API_Wrapper {
+
+  /**
+   * @var array
+   *   An instance of the custom value service.
+   */
+  protected $customValueService;
+
+  /**
+   * @param CustomValueService $customValueService
+   */
+  public function __construct(CustomValueService $customValueService) {
+    $this->customValueService = $customValueService;
+  }
 
   /**
    * {@inheritDoc} It Alters the Case Getcaselist action so it includes the case duration
@@ -12,7 +27,7 @@ class CRM_Civicaseextras_APIWrappers_Case_Getcaselist implements API_Wrapper {
     }
 
     $return = CRM_Utils_Array::value('return', $apiRequest['params'], []);
-    $caseDuration = CRM_Civicaseextras_Services_CustomValueService::getCustomField('case_stats', 'duration');
+    $caseDuration = $this->customValueService->getCustomField('case_stats', 'duration');
 
     if ($caseDuration) {
       $return[] = 'custom_' . $caseDuration['id'];

--- a/CRM/Civicaseextras/APIWrappers/Case/Getcaselist.php
+++ b/CRM/Civicaseextras/APIWrappers/Case/Getcaselist.php
@@ -12,7 +12,7 @@ class CRM_Civicaseextras_APIWrappers_Case_Getcaselist implements API_Wrapper {
     }
 
     $return = CRM_Utils_Array::value('return', $apiRequest['params'], []);
-    $caseDuration = _civicaseextras_get_caseDurationField();
+    $caseDuration = CRM_Civicaseextras_Services_CustomValueService::getCustomField('case_stats', 'duration');
 
     if ($caseDuration) {
       $return[] = 'custom_' . $caseDuration['id'];

--- a/CRM/Civicaseextras/AngularModifiers/CaseDuration.php
+++ b/CRM/Civicaseextras/AngularModifiers/CaseDuration.php
@@ -4,22 +4,31 @@ use \Civi\Angular\Manager as AngularManager;
 use \Civi\Angular\ChangeSet as AngularChangeSet;
 
 class CRM_Civicaseextras_AngularModifiers_CaseDuration {
+
+  /**
+   * @var AngularManager
+   *   A reference to the Angular Manager object as provided by the alter angular hook.
+   */
   protected $angular;
+
+  /**
+   * @var array
+   *   The case duration custom field information.
+   */
   protected $caseDuration;
 
   /**
    * @param AngularManager $angular as provided by the alter angular hook.
    */
-  public function __construct(AngularManager &$angular) {
+  public function __construct(AngularManager &$angular, $caseDurationCustomField) {
     $this->angular = $angular;
+    $this->caseDuration = $caseDurationCustomField;
   }
 
   /**
    * Adds the case duration column and value to the case list table template of civicase.
    */
   public function runModifications() {
-    $this->caseDuration = _civicaseextras_get_caseDurationField();
-
     $changeSet = AngularChangeSet::create('inject_case_duration')
       ->alterHtml('~/civicase/CaseListTable.html',
         function (phpQueryObject $doc) {

--- a/CRM/Civicaseextras/AngularModifiers/CaseDuration.php
+++ b/CRM/Civicaseextras/AngularModifiers/CaseDuration.php
@@ -1,7 +1,7 @@
 <?php
 
-use \Civi\Angular\Manager as AngularManager;
-use \Civi\Angular\ChangeSet as AngularChangeSet;
+use Civi\Angular\Manager as AngularManager;
+use Civi\Angular\ChangeSet as AngularChangeSet;
 
 class CRM_Civicaseextras_AngularModifiers_CaseDuration {
 

--- a/CRM/Civicaseextras/AngularModifiers/CaseDuration.php
+++ b/CRM/Civicaseextras/AngularModifiers/CaseDuration.php
@@ -1,0 +1,58 @@
+<?php
+
+use \Civi\Angular\Manager as AngularManager;
+use \Civi\Angular\ChangeSet as AngularChangeSet;
+
+class CRM_Civicaseextras_AngularModifiers_CaseDuration {
+  protected $angular;
+  protected $caseDuration;
+
+  /**
+   * @param AngularManager $angular as provided by the alter angular hook.
+   */
+  public function __construct(AngularManager &$angular) {
+    $this->angular = $angular;
+  }
+
+  /**
+   * Adds the case duration column and value to the case list table template of civicase.
+   */
+  public function runModifications() {
+    $this->caseDuration = _civicaseextras_get_caseDurationField();
+
+    $changeSet = AngularChangeSet::create('inject_case_duration')
+      ->alterHtml('~/civicase/CaseListTable.html',
+        function (phpQueryObject $doc) {
+          $this->addCaseDurationTableHeader($doc);
+          $this->addCaseDurationTableCell($doc);
+        });
+
+    $this->angular->add($changeSet);
+  }
+
+  /**
+   * Adds the case duration table header to the civicase list table.
+   *
+   * @param phpQueryObject $doc
+   */
+  protected function addCaseDurationTableHeader(phpQueryObject &$doc) {
+    $doc->find('.civicase__case-list-table thead tr')
+      ->append('<th
+        ng-show="!viewingCase && headers.length"
+        civicase-case-list-sort-header="custom_' . $this->caseDuration['id'] . '">
+        ' . $this->caseDuration['label'] . '
+      </th>');
+  }
+
+  /**
+   * Adds the case duration table cell to the civicase list table.
+   *
+   * @param phpQueryObject $doc
+   */
+  protected function addCaseDurationTableCell(phpQueryObject &$doc) {
+    $doc->find('.civicase__case-list-table tbody tr[ng-repeat="item in cases"]')
+      ->append('<td ng-show="!viewingCase && headers.length">
+        {{item.custom_' . $this->caseDuration['id'] . '}}
+      </td>');
+  }
+}

--- a/CRM/Civicaseextras/AngularModifiers/CaseDuration.php
+++ b/CRM/Civicaseextras/AngularModifiers/CaseDuration.php
@@ -13,18 +13,18 @@ class CRM_Civicaseextras_AngularModifiers_CaseDuration {
   protected $angular;
 
   /**
-   * @var array
-   *   The case duration custom field information.
+   * @var CustomValueService
+   *   an instance of the custom value service.
    */
-  protected $caseDuration;
+  protected $customValueService;
 
   /**
-   * @param AngularManager $angular as provided by the alter angular hook.
-   * @param CustomValueService $customValueService an instance of the custom value service.
+   * @param AngularManager $angular
+   * @param CustomValueService $customValueService
    */
   public function __construct(AngularManager &$angular, CustomValueService $customValueService) {
     $this->angular = $angular;
-    $this->caseDuration = $customValueService->getCustomField('case_stats', 'duration');
+    $this->customValueService = $customValueService;
   }
 
   /**
@@ -34,8 +34,10 @@ class CRM_Civicaseextras_AngularModifiers_CaseDuration {
     $changeSet = AngularChangeSet::create('inject_case_duration')
       ->alterHtml('~/civicase/CaseListTable.html',
         function (phpQueryObject $doc) {
-          $this->addCaseDurationTableHeader($doc);
-          $this->addCaseDurationTableCell($doc);
+          $caseDuration = $this->customValueService->getCustomField('case_stats', 'duration');
+
+          $this->addCaseDurationTableHeader($doc, $caseDuration);
+          $this->addCaseDurationTableCell($doc, $caseDuration);
         });
 
     $this->angular->add($changeSet);
@@ -45,13 +47,14 @@ class CRM_Civicaseextras_AngularModifiers_CaseDuration {
    * Adds the case duration table header to the civicase list table.
    *
    * @param phpQueryObject $doc
+   * @param array $caseDuration
    */
-  protected function addCaseDurationTableHeader(phpQueryObject &$doc) {
+  protected function addCaseDurationTableHeader(phpQueryObject &$doc, $caseDuration) {
     $doc->find('.civicase__case-list-table thead tr')
       ->append('<th
         ng-show="!viewingCase && headers.length"
-        civicase-case-list-sort-header="custom_' . $this->caseDuration['id'] . '">
-        ' . $this->caseDuration['label'] . '
+        civicase-case-list-sort-header="custom_' . $caseDuration['id'] . '">
+        ' . $caseDuration['label'] . '
       </th>');
   }
 
@@ -59,11 +62,12 @@ class CRM_Civicaseextras_AngularModifiers_CaseDuration {
    * Adds the case duration table cell to the civicase list table.
    *
    * @param phpQueryObject $doc
+   * @param array $caseDuration
    */
-  protected function addCaseDurationTableCell(phpQueryObject &$doc) {
+  protected function addCaseDurationTableCell(phpQueryObject &$doc, $caseDuration) {
     $doc->find('.civicase__case-list-table tbody tr[ng-repeat="item in cases"]')
       ->append('<td ng-show="!viewingCase && headers.length">
-        {{item.custom_' . $this->caseDuration['id'] . '}}
+        {{item.custom_' . $caseDuration['id'] . '}}
       </td>');
   }
 

--- a/CRM/Civicaseextras/AngularModifiers/CaseDuration.php
+++ b/CRM/Civicaseextras/AngularModifiers/CaseDuration.php
@@ -2,6 +2,7 @@
 
 use Civi\Angular\Manager as AngularManager;
 use Civi\Angular\ChangeSet as AngularChangeSet;
+use CRM_Civicaseextras_Services_CustomValueService as CustomValueService;
 
 class CRM_Civicaseextras_AngularModifiers_CaseDuration {
 
@@ -19,10 +20,11 @@ class CRM_Civicaseextras_AngularModifiers_CaseDuration {
 
   /**
    * @param AngularManager $angular as provided by the alter angular hook.
+   * @param CustomValueService $customValueService an instance of the custom value service.
    */
-  public function __construct(AngularManager &$angular, $caseDurationCustomField) {
+  public function __construct(AngularManager &$angular, CustomValueService $customValueService) {
     $this->angular = $angular;
-    $this->caseDuration = $caseDurationCustomField;
+    $this->caseDuration = $customValueService->getCustomField('case_stats', 'duration');
   }
 
   /**
@@ -64,4 +66,5 @@ class CRM_Civicaseextras_AngularModifiers_CaseDuration {
         {{item.custom_' . $this->caseDuration['id'] . '}}
       </td>');
   }
+
 }

--- a/CRM/Civicaseextras/AngularModifiers/OutcomesPanel.php
+++ b/CRM/Civicaseextras/AngularModifiers/OutcomesPanel.php
@@ -1,7 +1,7 @@
 <?php
 
-use \Civi\Angular\Manager as AngularManager;
-use \Civi\Angular\ChangeSet as AngularChangeSet;
+use Civi\Angular\Manager as AngularManager;
+use Civi\Angular\ChangeSet as AngularChangeSet;
 
 class CRM_Civicaseextras_AngularModifiers_OutcomesPanel {
 

--- a/CRM/Civicaseextras/AngularModifiers/OutcomesPanel.php
+++ b/CRM/Civicaseextras/AngularModifiers/OutcomesPanel.php
@@ -4,8 +4,12 @@ use \Civi\Angular\Manager as AngularManager;
 use \Civi\Angular\ChangeSet as AngularChangeSet;
 
 class CRM_Civicaseextras_AngularModifiers_OutcomesPanel {
+
+  /**
+   * @var AngularManager
+   *   A reference to the Angular Manager object as provided by the alter angular hook.
+   */
   protected $angular;
-  protected $caseDuration;
 
   /**
    * @param AngularManager $angular as provided by the alter angular hook.
@@ -15,7 +19,7 @@ class CRM_Civicaseextras_AngularModifiers_OutcomesPanel {
   }
 
   /**
-   * Adds the case duration column and value to the case list table template of civicase.
+   * Adds the case outcomes panel to the case details template of civicase.
    */
   public function runModifications() {
     $changeSet = AngularChangeSet::create('inject_case_outcomes')

--- a/CRM/Civicaseextras/AngularModifiers/OutcomesPanel.php
+++ b/CRM/Civicaseextras/AngularModifiers/OutcomesPanel.php
@@ -1,0 +1,31 @@
+<?php
+
+use \Civi\Angular\Manager as AngularManager;
+use \Civi\Angular\ChangeSet as AngularChangeSet;
+
+class CRM_Civicaseextras_AngularModifiers_OutcomesPanel {
+  protected $angular;
+  protected $caseDuration;
+
+  /**
+   * @param AngularManager $angular as provided by the alter angular hook.
+   */
+  public function __construct(AngularManager &$angular) {
+    $this->angular = $angular;
+  }
+
+  /**
+   * Adds the case duration column and value to the case list table template of civicase.
+   */
+  public function runModifications() {
+    $changeSet = AngularChangeSet::create('inject_case_outcomes')
+      ->alterHtml('~/civicase/CaseDetails--tabs--summary--CustomData.html',
+        function (phpQueryObject $doc) {
+          $doc->find('civicase-masonry-grid')
+            ->prepend('<civicase-extras-case-outcome case="item"></civicase-extras-case-outcome>');
+        });
+
+    $this->angular->add($changeSet);
+  }
+
+}

--- a/CRM/Civicaseextras/Services/CustomValueService.php
+++ b/CRM/Civicaseextras/Services/CustomValueService.php
@@ -6,7 +6,7 @@ class CRM_Civicaseextras_Services_CustomValueService {
    * @var array
    *   In-memory cache of custom fields
    */
-  protected static $customFields = [];
+  protected $customFields = [];
 
   /**
    * Fetches the data for a custom field.
@@ -16,13 +16,14 @@ class CRM_Civicaseextras_Services_CustomValueService {
    *
    * @return array
    */
-  public static function getCustomField($groupName, $fieldName) {
-    if (!isset(self::$customFields[$groupName][$fieldName])) {
+  public function getCustomField($groupName, $fieldName) {
+    if (!isset($this->customFields[$groupName][$fieldName])) {
       $params = ['name' => $fieldName, 'custom_group_id' => $groupName];
       $field = civicrm_api3('CustomField', 'getsingle', $params);
-      self::$customFields[$groupName][$fieldName] = $field;
+      $this->customFields[$groupName][$fieldName] = $field;
     }
 
-    return self::$customFields[$groupName][$fieldName];
+    return $this->customFields[$groupName][$fieldName];
   }
+
 }

--- a/CRM/Civicaseextras/Services/CustomValueService.php
+++ b/CRM/Civicaseextras/Services/CustomValueService.php
@@ -1,0 +1,28 @@
+<?php
+
+class CRM_Civicaseextras_Services_CustomValueService {
+
+  /**
+   * @var array
+   *   In-memory cache of custom fields
+   */
+  protected static $customFields = [];
+
+  /**
+   * Fetches the data for a custom field.
+   *
+   * @param string $groupName
+   * @param string $fieldName
+   *
+   * @return array
+   */
+  public static function getCustomField($groupName, $fieldName) {
+    if (!isset(self::$customFields[$groupName][$fieldName])) {
+      $params = ['name' => $fieldName, 'custom_group_id' => $groupName];
+      $field = civicrm_api3('CustomField', 'getsingle', $params);
+      self::$customFields[$groupName][$fieldName] = $field;
+    }
+
+    return self::$customFields[$groupName][$fieldName];
+  }
+}

--- a/civicaseextras.civix.php
+++ b/civicaseextras.civix.php
@@ -502,6 +502,58 @@ function _civicaseextras_civicrm_alterAngular(\Civi\Angular\Manager &$angular) {
 }
 
 /**
+ * (Delegated) Implements hook_civicrm_alterAngular().
+ */
+function _civicaseextras_civicrm_alterAngular(\Civi\Angular\Manager &$angular) {
+  _civicaseextras_civicrm_alterAngular__addCaseDurationToCaseList($angular);
+}
+
+/**
+ * Adds the case duration column and value to the case list table template of civicase.
+ *
+ * @param Manager $angular as provided by the alter angular hook.
+ */
+function _civicaseextras_civicrm_alterAngular__addCaseDurationToCaseList (\Civi\Angular\Manager &$angular) {
+  $changeSet = \Civi\Angular\ChangeSet::create('inject_case_duration')
+    ->alterHtml('~/civicase/CaseListTable.html',
+      function (phpQueryObject $doc) {
+        $caseDuration = _civicaseextras_get_caseDurationField();
+
+        _civicaseextras_civicrm_alterAngular__addCaseDurationTableHeader($doc, $caseDuration);
+        _civicaseextras_civicrm_alterAngular__addCaseDurationTableCell($doc, $caseDuration);
+      });
+  $angular->add($changeSet);
+}
+
+/**
+ * Adds the case duration table header to the civicase list table.
+ *
+ * @param phpQueryObject $doc
+ * @param array $caseDuration
+ */
+function _civicaseextras_civicrm_alterAngular__addCaseDurationTableHeader(&$doc, $caseDuration) {
+  $doc->find('.civicase__case-list-table thead tr')
+    ->append('<th
+      ng-show="!viewingCase && headers.length"
+      civicase-case-list-sort-header="custom_' . $caseDuration['id'] . '">
+      ' . $caseDuration['label'] . '
+    </th>');
+}
+
+/**
+ * Adds the case duration table cell to the civicase list table.
+ *
+ * @param phpQueryObject $doc
+ * @param array $caseDuration
+ */
+function _civicaseextras_civicrm_alterAngular__addCaseDurationTableCell(&$doc, $caseDuration) {
+  $doc->find('.civicase__case-list-table tbody tr[ng-repeat="item in cases"]')
+    ->append('<td ng-show="!viewingCase && headers.length">
+      {{item.custom_' . $caseDuration['id'] . '}}
+    </td>');
+}
+
+/**
  * Returns the details for the case duration custom fields.
  *
  * @return array

--- a/civicaseextras.civix.php
+++ b/civicaseextras.civix.php
@@ -490,25 +490,14 @@ function _civicaseextras_civix_civicrm_entityTypes(&$entityTypes) {
  * (Delegated) Implements hook_civicrm_alterAngular().
  */
 function _civicaseextras_civicrm_alterAngular(\Civi\Angular\Manager &$angular) {
-  _civicaseextras_civicrm_alterAngular__addCaseOutcomesPanel($angular);
+  $modifiers = [
+    new CRM_Civicaseextras_AngularModifiers_CaseDuration($angular),
+    new CRM_Civicaseextras_AngularModifiers_OutcomesPanel($angular),
+  ];
 
-  $caseDuration = new CRM_Civicaseextras_AngularModifiers_CaseDuration($angular);
-  $caseDuration->runModifications();
-}
-
-/**
- * Adds a case outcomes panel to the case details.
- *
- * @param Manager $angular as provided by the alter angular hook.
- */
-function _civicaseextras_civicrm_alterAngular__addCaseOutcomesPanel(\Civi\Angular\Manager &$angular) {
-  $changeSet = \Civi\Angular\ChangeSet::create('inject_case_outcomes')
-    ->alterHtml('~/civicase/CaseDetails--tabs--summary--CustomData.html',
-      function (phpQueryObject $doc) {
-        $doc->find('civicase-masonry-grid')
-          ->prepend('<civicase-extras-case-outcome case="item"></civicase-extras-case-outcome>');
-      });
-  $angular->add($changeSet);
+  foreach ($modifiers as $modifier) {
+    $modifier->runModifications();
+  }
 }
 
 /**

--- a/civicaseextras.civix.php
+++ b/civicaseextras.civix.php
@@ -486,6 +486,11 @@ function _civicaseextras_civix_civicrm_entityTypes(&$entityTypes) {
   ));
 }
 
+/**
+ * Adds the case duration column and value to the case list table template of civicase.
+ *
+ * @param Manager $angular as provided by the alter angular hook.
+ */
 function _civicaseextras_civicrm_alterAngular(\Civi\Angular\Manager &$angular) {
   $changeSet = \Civi\Angular\ChangeSet::create('inject_case_outcomes')
     ->alterHtml('~/civicase/CaseDetails--tabs--summary--CustomData.html',
@@ -494,4 +499,18 @@ function _civicaseextras_civicrm_alterAngular(\Civi\Angular\Manager &$angular) {
           ->prepend('<civicase-extras-case-outcome case="item"></civicase-extras-case-outcome>');
       });
   $angular->add($changeSet);
+}
+
+/**
+ * Returns the details for the case duration custom fields.
+ *
+ * @return array
+ */
+function _civicaseextras_get_caseDurationField () {
+  $caseDuration = civicrm_api3('CustomField', 'get', [
+    'custom_group_id' => 'Case_Stats',
+    'name' => 'duration'
+  ]);
+
+  return CRM_Utils_Array::first($caseDuration['values'], []);
 }

--- a/civicaseextras.civix.php
+++ b/civicaseextras.civix.php
@@ -307,27 +307,18 @@ function _civicaseextras_civix_civicrm_caseTypes(&$caseTypes) {
 }
 
 /**
- * (Delegated) Implements hook_civicrm_angularModules(). *
+ * (Delegated) Implements hook_civicrm_angularModules().
+ *
+ * Find any and return any files matching "ang/*.ang.php"
  *
  * Note: This hook only runs in CiviCRM 4.5+.
  *
  * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_angularModules
  */
 function _civicaseextras_civix_civicrm_angularModules(&$angularModules) {
-  _civicaseextras_includeAngularModules($angularModules);
-  _civicaseextras_addCiviCaseExtrasAsRequirementForCivicase($angularModules);
-}
-
-/**
- * Find any and return any files matching "ang/*.ang.php" and includes them as angular modules.
- *
- * @param Array $angularModules
- */
-function _civicaseextras_includeAngularModules(&$angularModules) {
   if (!is_dir(__DIR__ . '/ang')) {
     return;
   }
-
   $files = _civicaseextras_civix_glob(__DIR__ . '/ang/*.ang.php');
   foreach ($files as $file) {
     $name = preg_replace(':\.ang\.php$:', '', basename($file));
@@ -338,25 +329,6 @@ function _civicaseextras_includeAngularModules(&$angularModules) {
     $angularModules[$name] = $module;
   }
 }
-
-/**
- * Add civicase extras as a requirement of civicase
- *
- * @param Array $angularModules
- */
-function _civicaseextras_addCiviCaseExtrasAsRequirementForCivicase(&$angularModules) {
-  if (isset($angularModules['civicase'])) {
-    $angularModules['civicase']['requires'][] = 'civicaseextras';
-  } else {
-    CRM_Core_Session::setStatus(
-      'The <strong>Civicase Extras</strong> extension requires <strong>CiviCase</strong> to be installed first.',
-      'Warning',
-      'no-popup'
-    );
-  }
-}
-
-
 
 /**
  * Glob wrapper which is guaranteed to return an array.
@@ -484,32 +456,4 @@ function _civicaseextras_civix_civicrm_alterSettingsFolders(&$metaDataFolders = 
 function _civicaseextras_civix_civicrm_entityTypes(&$entityTypes) {
   $entityTypes = array_merge($entityTypes, array (
   ));
-}
-
-/**
- * (Delegated) Implements hook_civicrm_alterAngular().
- */
-function _civicaseextras_civicrm_alterAngular(\Civi\Angular\Manager &$angular) {
-  $modifiers = [
-    new CRM_Civicaseextras_AngularModifiers_CaseDuration($angular),
-    new CRM_Civicaseextras_AngularModifiers_OutcomesPanel($angular),
-  ];
-
-  foreach ($modifiers as $modifier) {
-    $modifier->runModifications();
-  }
-}
-
-/**
- * Returns the details for the case duration custom fields.
- *
- * @return array
- */
-function _civicaseextras_get_caseDurationField () {
-  $caseDuration = civicrm_api3('CustomField', 'get', [
-    'custom_group_id' => 'Case_Stats',
-    'name' => 'duration'
-  ]);
-
-  return CRM_Utils_Array::first($caseDuration['values'], []);
 }

--- a/civicaseextras.civix.php
+++ b/civicaseextras.civix.php
@@ -487,11 +487,19 @@ function _civicaseextras_civix_civicrm_entityTypes(&$entityTypes) {
 }
 
 /**
- * Adds the case duration column and value to the case list table template of civicase.
+ * (Delegated) Implements hook_civicrm_alterAngular().
+ */
+function _civicaseextras_civicrm_alterAngular(\Civi\Angular\Manager &$angular) {
+  _civicaseextras_civicrm_alterAngular__addCaseOutcomesPanel($angular);
+  _civicaseextras_civicrm_alterAngular__addCaseDurationToCaseList($angular);
+}
+
+/**
+ * Adds a case outcomes panel to the case details.
  *
  * @param Manager $angular as provided by the alter angular hook.
  */
-function _civicaseextras_civicrm_alterAngular(\Civi\Angular\Manager &$angular) {
+function _civicaseextras_civicrm_alterAngular__addCaseOutcomesPanel(\Civi\Angular\Manager &$angular) {
   $changeSet = \Civi\Angular\ChangeSet::create('inject_case_outcomes')
     ->alterHtml('~/civicase/CaseDetails--tabs--summary--CustomData.html',
       function (phpQueryObject $doc) {
@@ -499,13 +507,6 @@ function _civicaseextras_civicrm_alterAngular(\Civi\Angular\Manager &$angular) {
           ->prepend('<civicase-extras-case-outcome case="item"></civicase-extras-case-outcome>');
       });
   $angular->add($changeSet);
-}
-
-/**
- * (Delegated) Implements hook_civicrm_alterAngular().
- */
-function _civicaseextras_civicrm_alterAngular(\Civi\Angular\Manager &$angular) {
-  _civicaseextras_civicrm_alterAngular__addCaseDurationToCaseList($angular);
 }
 
 /**

--- a/civicaseextras.civix.php
+++ b/civicaseextras.civix.php
@@ -491,7 +491,9 @@ function _civicaseextras_civix_civicrm_entityTypes(&$entityTypes) {
  */
 function _civicaseextras_civicrm_alterAngular(\Civi\Angular\Manager &$angular) {
   _civicaseextras_civicrm_alterAngular__addCaseOutcomesPanel($angular);
-  _civicaseextras_civicrm_alterAngular__addCaseDurationToCaseList($angular);
+
+  $caseDuration = new CRM_Civicaseextras_AngularModifiers_CaseDuration($angular);
+  $caseDuration->runModifications();
 }
 
 /**
@@ -507,51 +509,6 @@ function _civicaseextras_civicrm_alterAngular__addCaseOutcomesPanel(\Civi\Angula
           ->prepend('<civicase-extras-case-outcome case="item"></civicase-extras-case-outcome>');
       });
   $angular->add($changeSet);
-}
-
-/**
- * Adds the case duration column and value to the case list table template of civicase.
- *
- * @param Manager $angular as provided by the alter angular hook.
- */
-function _civicaseextras_civicrm_alterAngular__addCaseDurationToCaseList (\Civi\Angular\Manager &$angular) {
-  $changeSet = \Civi\Angular\ChangeSet::create('inject_case_duration')
-    ->alterHtml('~/civicase/CaseListTable.html',
-      function (phpQueryObject $doc) {
-        $caseDuration = _civicaseextras_get_caseDurationField();
-
-        _civicaseextras_civicrm_alterAngular__addCaseDurationTableHeader($doc, $caseDuration);
-        _civicaseextras_civicrm_alterAngular__addCaseDurationTableCell($doc, $caseDuration);
-      });
-  $angular->add($changeSet);
-}
-
-/**
- * Adds the case duration table header to the civicase list table.
- *
- * @param phpQueryObject $doc
- * @param array $caseDuration
- */
-function _civicaseextras_civicrm_alterAngular__addCaseDurationTableHeader(&$doc, $caseDuration) {
-  $doc->find('.civicase__case-list-table thead tr')
-    ->append('<th
-      ng-show="!viewingCase && headers.length"
-      civicase-case-list-sort-header="custom_' . $caseDuration['id'] . '">
-      ' . $caseDuration['label'] . '
-    </th>');
-}
-
-/**
- * Adds the case duration table cell to the civicase list table.
- *
- * @param phpQueryObject $doc
- * @param array $caseDuration
- */
-function _civicaseextras_civicrm_alterAngular__addCaseDurationTableCell(&$doc, $caseDuration) {
-  $doc->find('.civicase__case-list-table tbody tr[ng-repeat="item in cases"]')
-    ->append('<td ng-show="!viewingCase && headers.length">
-      {{item.custom_' . $caseDuration['id'] . '}}
-    </td>');
 }
 
 /**

--- a/civicaseextras.php
+++ b/civicaseextras.php
@@ -113,6 +113,7 @@ function civicaseextras_civicrm_caseTypes(&$caseTypes) {
  */
 function civicaseextras_civicrm_angularModules(&$angularModules) {
   _civicaseextras_civix_civicrm_angularModules($angularModules);
+  _civicaseextras_addCiviCaseExtrasAsRequirementForCivicase($angularModules);
 }
 
 /**
@@ -139,7 +140,14 @@ function civicaseextras_civicrm_entityTypes(&$entityTypes) {
  * Implements hook_civicrm_alterAngular().
  */
 function civicaseextras_civicrm_alterAngular(AngularManager $angular) {
-  _civicaseextras_civicrm_alterAngular($angular);
+  $modifiers = [
+    new CRM_Civicaseextras_AngularModifiers_CaseDuration($angular),
+    new CRM_Civicaseextras_AngularModifiers_OutcomesPanel($angular),
+  ];
+
+  foreach ($modifiers as $modifier) {
+    $modifier->runModifications();
+  }
 }
 
 /**
@@ -148,6 +156,38 @@ function civicaseextras_civicrm_alterAngular(AngularManager $angular) {
 function civicaseextras_civicrm_apiWrappers(&$wrappers, $apiRequest) {
   $wrappers[] = new CRM_Civicaseextras_APIWrappers_Case_Getcaselist();
 }
+
+/**
+ * Add civicase extras as a requirement of civicase
+ *
+ * @param Array $angularModules
+ */
+function _civicaseextras_addCiviCaseExtrasAsRequirementForCivicase(&$angularModules) {
+  if (isset($angularModules['civicase'])) {
+    $angularModules['civicase']['requires'][] = 'civicaseextras';
+  } else {
+    CRM_Core_Session::setStatus(
+      'The <strong>Civicase Extras</strong> extension requires <strong>CiviCase</strong> to be installed first.',
+      'Warning',
+      'no-popup'
+    );
+  }
+}
+
+/**
+ * Returns the details for the case duration custom fields.
+ *
+ * @return array
+ */
+function _civicaseextras_get_caseDurationField () {
+  $caseDuration = civicrm_api3('CustomField', 'get', [
+    'custom_group_id' => 'Case_Stats',
+    'name' => 'duration'
+  ]);
+
+  return CRM_Utils_Array::first($caseDuration['values'], []);
+}
+
 
 // --- Functions below this ship commented out. Uncomment as required. ---
 

--- a/civicaseextras.php
+++ b/civicaseextras.php
@@ -162,12 +162,13 @@ function civicaseextras_civicrm_apiWrappers(&$wrappers, $apiRequest) {
 /**
  * Add civicase extras as a requirement of civicase
  *
- * @param Array $angularModules
+ * @param array $angularModules
  */
 function _civicaseextras_addCiviCaseExtrasAsRequirementForCivicase(&$angularModules) {
   if (isset($angularModules['civicase'])) {
     $angularModules['civicase']['requires'][] = 'civicaseextras';
-  } else {
+  }
+  else {
     CRM_Core_Session::setStatus(
       'The <strong>Civicase Extras</strong> extension requires <strong>CiviCase</strong> to be installed first.',
       'Warning',

--- a/civicaseextras.php
+++ b/civicaseextras.php
@@ -1,8 +1,9 @@
 <?php
 
 require_once 'civicaseextras.civix.php';
+use Civi\Angular\Manager as AngularManager;
 use CRM_Civicaseextras_ExtensionUtil as E;
-use \Civi\Angular\Manager as AngularManager;
+use CRM_Civicaseextras_Services_CustomValueService as CustomValueService;
 
 /**
  * Implements hook_civicrm_config().
@@ -140,10 +141,10 @@ function civicaseextras_civicrm_entityTypes(&$entityTypes) {
  * Implements hook_civicrm_alterAngular().
  */
 function civicaseextras_civicrm_alterAngular(AngularManager $angular) {
-  $caseDurationCustomField = CRM_Civicaseextras_Services_CustomValueService::getCustomField('case_stats', 'duration');
+  $customValueService = new CustomValueService();
 
   $modifiers = [
-    new CRM_Civicaseextras_AngularModifiers_CaseDuration($angular, $caseDurationCustomField),
+    new CRM_Civicaseextras_AngularModifiers_CaseDuration($angular, $customValueService),
     new CRM_Civicaseextras_AngularModifiers_OutcomesPanel($angular),
   ];
 
@@ -156,7 +157,9 @@ function civicaseextras_civicrm_alterAngular(AngularManager $angular) {
  * Implements hook_civicrm_apiWrappers().
  */
 function civicaseextras_civicrm_apiWrappers(&$wrappers, $apiRequest) {
-  $wrappers[] = new CRM_Civicaseextras_APIWrappers_Case_Getcaselist();
+  $customValueService = new CustomValueService();
+
+  $wrappers[] = new CRM_Civicaseextras_APIWrappers_Case_Getcaselist($customValueService);
 }
 
 /**

--- a/civicaseextras.php
+++ b/civicaseextras.php
@@ -140,8 +140,10 @@ function civicaseextras_civicrm_entityTypes(&$entityTypes) {
  * Implements hook_civicrm_alterAngular().
  */
 function civicaseextras_civicrm_alterAngular(AngularManager $angular) {
+  $caseDurationCustomField = CRM_Civicaseextras_Services_CustomValueService::getCustomField('case_stats', 'duration');
+
   $modifiers = [
-    new CRM_Civicaseextras_AngularModifiers_CaseDuration($angular),
+    new CRM_Civicaseextras_AngularModifiers_CaseDuration($angular, $caseDurationCustomField),
     new CRM_Civicaseextras_AngularModifiers_OutcomesPanel($angular),
   ];
 
@@ -173,21 +175,6 @@ function _civicaseextras_addCiviCaseExtrasAsRequirementForCivicase(&$angularModu
     );
   }
 }
-
-/**
- * Returns the details for the case duration custom fields.
- *
- * @return array
- */
-function _civicaseextras_get_caseDurationField () {
-  $caseDuration = civicrm_api3('CustomField', 'get', [
-    'custom_group_id' => 'Case_Stats',
-    'name' => 'duration'
-  ]);
-
-  return CRM_Utils_Array::first($caseDuration['values'], []);
-}
-
 
 // --- Functions below this ship commented out. Uncomment as required. ---
 

--- a/civicaseextras.php
+++ b/civicaseextras.php
@@ -134,8 +134,20 @@ function civicaseextras_civicrm_entityTypes(&$entityTypes) {
   _civicaseextras_civix_civicrm_entityTypes($entityTypes);
 }
 
+/**
+ * Implements hook_civicrm_alterAngular().
+ */
 function civicaseextras_civicrm_alterAngular(\Civi\Angular\Manager $angular) {
   _civicaseextras_civicrm_alterAngular($angular);
+}
+
+/**
+ * Implements hook_civicrm_apiWrappers().
+ */
+function civicaseextras_civicrm_apiWrappers(&$wrappers, $apiRequest) {
+  if ($apiRequest['entity'] == 'Case' && $apiRequest['action'] == 'getcaselist') {
+    $wrappers[] = new CRM_Civicaseextras_APIWrappers_Case_Getcaselist();
+  }
 }
 
 // --- Functions below this ship commented out. Uncomment as required. ---

--- a/civicaseextras.php
+++ b/civicaseextras.php
@@ -2,6 +2,7 @@
 
 require_once 'civicaseextras.civix.php';
 use CRM_Civicaseextras_ExtensionUtil as E;
+use \Civi\Angular\Manager as AngularManager;
 
 /**
  * Implements hook_civicrm_config().
@@ -137,7 +138,7 @@ function civicaseextras_civicrm_entityTypes(&$entityTypes) {
 /**
  * Implements hook_civicrm_alterAngular().
  */
-function civicaseextras_civicrm_alterAngular(\Civi\Angular\Manager $angular) {
+function civicaseextras_civicrm_alterAngular(AngularManager $angular) {
   _civicaseextras_civicrm_alterAngular($angular);
 }
 
@@ -145,9 +146,7 @@ function civicaseextras_civicrm_alterAngular(\Civi\Angular\Manager $angular) {
  * Implements hook_civicrm_apiWrappers().
  */
 function civicaseextras_civicrm_apiWrappers(&$wrappers, $apiRequest) {
-  if ($apiRequest['entity'] == 'Case' && $apiRequest['action'] == 'getcaselist') {
-    $wrappers[] = new CRM_Civicaseextras_APIWrappers_Case_Getcaselist();
-  }
+  $wrappers[] = new CRM_Civicaseextras_APIWrappers_Case_Getcaselist();
 }
 
 // --- Functions below this ship commented out. Uncomment as required. ---

--- a/civicaseextras.php
+++ b/civicaseextras.php
@@ -142,6 +142,13 @@ function civicaseextras_civicrm_alterAngular(\Civi\Angular\Manager $angular) {
 }
 
 /**
+ * Implements hook_civicrm_alterAngular().
+ */
+function civicaseextras_civicrm_alterAngular(\Civi\Angular\Manager $angular) {
+  _civicaseextras_civicrm_alterAngular($angular);
+}
+
+/**
  * Implements hook_civicrm_apiWrappers().
  */
 function civicaseextras_civicrm_apiWrappers(&$wrappers, $apiRequest) {

--- a/civicaseextras.php
+++ b/civicaseextras.php
@@ -142,13 +142,6 @@ function civicaseextras_civicrm_alterAngular(\Civi\Angular\Manager $angular) {
 }
 
 /**
- * Implements hook_civicrm_alterAngular().
- */
-function civicaseextras_civicrm_alterAngular(\Civi\Angular\Manager $angular) {
-  _civicaseextras_civicrm_alterAngular($angular);
-}
-
-/**
  * Implements hook_civicrm_apiWrappers().
  */
 function civicaseextras_civicrm_apiWrappers(&$wrappers, $apiRequest) {


### PR DESCRIPTION
## Overview

This PR displays the case duration on the civicase list table template.

📘 For more information about the case duration field please refer to https://github.com/compucorp/uk.co.compucorp.civicaseexrtas/pull/3

⚠️ **Important:** this PR depends on https://github.com/compucorp/uk.co.compucorp.civicase/pull/78 and https://github.com/compucorp/uk.co.compucorp.civicaseexrtas/pull/3

## Before
![pr-before](https://user-images.githubusercontent.com/1642119/47326496-f9a94c00-d636-11e8-82c5-3d3916456bf1.gif)
(The case duration field is not displayed)

## After
![pr-after](https://user-images.githubusercontent.com/1642119/47326466-da122380-d636-11e8-87fc-c6b53f34a077.gif)

## Technical details

### Adding the case duration to the API response

In order to display the case duration it was necessary to return it on the API result for the Case's Getcaselist action. To accomplish this the `APIWrapper` hook was implemented:

```php
function civicaseextras_civicrm_apiWrappers(&$wrappers, $apiRequest) {
  if ($apiRequest['entity'] == 'Case' && $apiRequest['action'] == 'getcaselist') {
    $wrappers[] = new CRM_Civicaseextras_APIWrappers_Case_Getcaselist();
  }
}
```

The important part about the `CRM_Civicaseextras_APIWrappers_Case_Getcaselist` is it's `fromApiInput` method:

```php
    public function fromApiInput($apiRequest) {
      $return = CRM_Utils_Array::value('return', $apiRequest['params'], []);
      $caseDuration = _civicaseextras_get_caseDurationField();
       if ($caseDuration) {
        $return[] = 'custom_' . $caseDuration['id'];
      }
       $apiRequest['params']['return'] = $return;
       return $apiRequest;
    }
```

A helper `_civicaseextras_get_caseDurationField` function was created which returns the case duration custom field information:

```php
function _civicaseextras_get_caseDurationField () {
  $caseDuration = civicrm_api3('CustomField', 'get', [
    'custom_group_id' => 'Case_Stats',
    'name' => 'duration'
  ]);
   return CRM_Utils_Array::first($caseDuration['values'], []);
}
```

ℹ️ For more information about the `APIWrapper` hook please refer to [this guide](https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_apiWrappers/).

### Displaying the case duration field

To add the field to the template the `alterAngular` hook was implemented:

```php
function _civicaseextras_civicrm_alterAngular(\Civi\Angular\Manager &$angular) {
  _civicaseextras_civicrm_alterAngular__addCaseDurationToCaseList($angular);
}

function _civicaseextras_civicrm_alterAngular__addCaseDurationToCaseList (\Civi\Angular\Manager &$angular) {
  $changeSet = \Civi\Angular\ChangeSet::create('inject_case_duration')
    ->alterHtml('~/civicase/CaseListTable.html',
      function (phpQueryObject $doc) {
        $caseDuration = _civicaseextras_get_caseDurationField();
         _civicaseextras_civicrm_alterAngular__addCaseDurationTableHeader($doc, $caseDuration);
        _civicaseextras_civicrm_alterAngular__addCaseDurationTableCell($doc, $caseDuration);
      });
  $angular->add($changeSet);
}

function _civicaseextras_civicrm_alterAngular__addCaseDurationTableHeader(&$doc, $caseDuration) {
  $doc->find('.civicase__case-list-table thead tr')
    ->append('<th
      ng-show="!viewingCase && headers.length"
      civicase-case-list-sort-header="custom_' . $caseDuration['id'] . '">
      ' . $caseDuration['label'] . '
    </th>');
}

function _civicaseextras_civicrm_alterAngular__addCaseDurationTableCell(&$doc, $caseDuration) {
  $doc->find('.civicase__case-list-table tbody tr[ng-repeat="item in cases"]')
    ->append('<td ng-show="!viewingCase && headers.length">
      {{item.custom_' . $caseDuration['id'] . '}}
    </td>');
}
```

## Comments

The `toApiOutput` method was defined because it's required to be implemented, but it just returns the response the same as it came without any modifications.
