### PR TITLE
C51-284: last updated warning

### DIFF
--- a/ang/civicaseextras/formatCase.decorator.js
+++ b/ang/civicaseextras/formatCase.decorator.js
@@ -1,16 +1,26 @@
-(function (angular) {
+(function (angular, caseStatuses) {
   var module = angular.module('civicase');
-
-  console.log('@', angular.module('civicase'));
 
   module.config(function ($provide) {
     $provide.decorator('formatCase', function ($delegate) {
-      var originalFormatCase = $delegate[0];
-      console.log('.', originalFormatCase);
+      var originalFormatCase = $delegate;
 
-      return function formatCaseFactory (formatActivity, ContactsDataService) {
-        console.log('@', formatActivity, ContactsDataService, originalFormatCase);
+      /**
+       * Enhances the formatCase method so it adds information about overfue dates for the case.
+       *
+       * @param {Object} caseItem
+       * @return {Object}
+       */
+      return function formatCase (caseItem) {
+        var isStatusOpen = caseStatuses[caseItem.status_id].grouping === 'Opened';
+        var isModifiedDateOverdue = moment().subtract(3, 'months').isSameOrAfter(caseItem.modified_date);
+        caseItem = originalFormatCase(caseItem);
+        caseItem.overdueDates = {
+          modified_date: isStatusOpen && isModifiedDateOverdue
+        };
+
+        return caseItem;
       };
     });
   });
-})(angular);
+})(angular, CRM.civicase.caseStatuses);

--- a/ang/civicaseextras/formatCase.decorator.js
+++ b/ang/civicaseextras/formatCase.decorator.js
@@ -1,0 +1,16 @@
+(function (angular) {
+  var module = angular.module('civicase');
+
+  console.log('@', angular.module('civicase'));
+
+  module.config(function ($provide) {
+    $provide.decorator('formatCase', function ($delegate) {
+      var originalFormatCase = $delegate[0];
+      console.log('.', originalFormatCase);
+
+      return function formatCaseFactory (formatActivity, ContactsDataService) {
+        console.log('@', formatActivity, ContactsDataService, originalFormatCase);
+      };
+    });
+  });
+})(angular);

--- a/civicaseextras.civix.php
+++ b/civicaseextras.civix.php
@@ -1,5 +1,8 @@
 <?php
 
+use \Civi\Angular\ChangeSet as AngularChangeSet;
+use \Civi\Angular\Manager as AngularManager;
+
 // AUTO-GENERATED FILE -- Civix may overwrite any changes made to this file
 
 /**
@@ -486,8 +489,48 @@ function _civicaseextras_civix_civicrm_entityTypes(&$entityTypes) {
   ));
 }
 
-function _civicaseextras_civicrm_alterAngular(\Civi\Angular\Manager &$angular) {
-  $changeSet = \Civi\Angular\ChangeSet::create('inject_case_outcomes')
+/**
+ * Executes the angular alterations for Civicase.
+ *
+ * @param $angular AngularManager
+ */
+function _civicaseextras_civicrm_alterAngular(AngularManager &$angular) {
+  _civicaseextras_alterAngular_addVisualAlert($angular);
+  _civicaseextras_alterAngular_appendOutcomePanel($angular);
+}
+
+/**
+ * Replaces the date column type on case lists so it displays an alert when the
+ * given date is overdue.
+ *
+ * @param $angular AngularManager
+ */
+function _civicaseextras_alterAngular_addVisualAlert (AngularManager &$angular) {
+  $changeSet = AngularChangeSet::create('display_warning_for_overdue_cases')
+    ->alterHtml('~/civicase/CaseListTable.html',
+      function (phpQueryObject $doc) {
+        $doc->find('[ng-switch-when="date"]')
+          ->html('
+            <span ng-if="!item.overdueDates[header.name]">
+              {{ CRM.utils.formatDate(item[header.name]) }}
+            </span>
+            <strong ng-if="item.overdueDates[header.name]"
+              class="text-danger">
+              {{ CRM.utils.formatDate(item[header.name]) }}
+              <i class="material-icons civicase__icon">error</i>
+            </strong>
+          ');
+      });
+  $angular->add($changeSet);
+}
+
+/**
+ * Appends the case outcomes to the case details summary.
+ *
+ * @param $angular AngularManager
+ */
+function _civicaseextras_alterAngular_appendOutcomePanel (AngularManager &$angular) {
+  $changeSet = AngularChangeSet::create('inject_case_outcomes')
     ->alterHtml('~/civicase/CaseDetails--tabs--summary--CustomData.html',
       function (phpQueryObject $doc) {
         $doc->find('civicase-masonry-grid')

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "globals": [
       "CRM",
       "angular",
-      "inject"
+      "inject",
+      "moment"
     ]
   },
   "repository": {


### PR DESCRIPTION
## Overview
This PR adds a visual alert to the modified date field for cases that have been last modified 3 months ago.

⚠️ **Important:** this PR depends on https://github.com/compucorp/uk.co.compucorp.civicase/pull/180

## Before
![pr-before](https://user-images.githubusercontent.com/1642119/49481674-49685f00-f802-11e8-8cc3-b4a28e6e64d1.png)

## After
![pr-after](https://user-images.githubusercontent.com/1642119/49481554-d8c14280-f801-11e8-9db4-ea381fb8cd77.png)

## Technical details

### Marking the modified date as overdue

Civicase's `formatCase` was decorated in order to mark the date as overdue. This decorator would pass the case data to the original `formatCase` and then add an `overdueDates` map to the case:

```js
      function formatCase (caseItem) {
        var isStatusOpen = caseStatuses[caseItem.status_id].grouping === 'Opened';
        var isModifiedDateOverdue = moment().subtract(3, 'months').isSameOrAfter(caseItem.modified_date);
        caseItem = originalFormatCase(caseItem);
        caseItem.overdueDates = {
          modified_date: isStatusOpen && isModifiedDateOverdue
        };

        return caseItem;
      };
```

The information is stored in a map since the list table uses column types and the condition would have been more complicated with a simple field. For example:

```html
<span ng-if="header.name === 'modified_date' && item.modifiedDateIsOverdue">
```

With this approach we can simplify the condition to:

```html
<span ng-if="item.overdueDates[header.name]">
```

This also makes the implementation future proof in case we need to mark other dates as overdue.

### Displaying the overdue warning

We need to alter the original list table template in order to display the warning. As explained before, the table columns are displayed depending of their type as seen here:
https://github.com/compucorp/uk.co.compucorp.civicase/blob/master/ang/civicase/CaseListTable.html#L98

The template was changed using [civiCRM's alter angular hook](https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_alterAngular/) by replacing the content of the `[ng-switch-when="date"]` column with:

```html
<span ng-if="!item.overdueDates[header.name]">
  {{ CRM.utils.formatDate(item[header.name]) }}
</span>
<strong ng-if="item.overdueDates[header.name]"
  class="text-danger">
  {{ CRM.utils.formatDate(item[header.name]) }}
  <i class="material-icons civicase__icon">error</i>
</strong>
```

The `civicase__icon` class is used to properly align the icon against the date.