### PR TITLE
C51-284: Change settings name

### DIFF
--- a/ang/civicaseextras.ang.php
+++ b/ang/civicaseextras.ang.php
@@ -19,7 +19,7 @@ function getCivicaseExtrasJSFiles () {
  */
 function getCivicaseExtrasSettings () {
   return [
-    'overdueNotificationLimit' => (int) Civi::settings()->get('civicaseOverdueNotificationLimit'),
+    'overdueNotificationLimit' => (int) Civi::settings()->get('civicaseCaseLastUpdatedNotificationLimit'),
   ];
 }
 

--- a/civicaseextras.php
+++ b/civicaseextras.php
@@ -191,7 +191,7 @@ function _civicaseextras_alterContent_addCivicaseAdminSettingsFields (&$content)
  */
 function _civicaseextras_preProcess_addCivicaseAdminSettingsFieldsReference (&$form) {
   $settings = $form->getVar('_settings');
-  $settings['civicaseOverdueNotificationLimit'] = CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME;
+  $settings['civicaseCaseLastUpdatedNotificationLimit'] = CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME;
 
   $form->setVar('_settings', $settings);
 }

--- a/settings/Civicaseextras.setting.php
+++ b/settings/Civicaseextras.setting.php
@@ -1,10 +1,10 @@
 <?php
 
 return [
-  'civicaseOverdueNotificationLimit' => [
+  'civicaseCaseLastUpdatedNotificationLimit' => [
     'group_name' => 'CiviCRM Preferences',
     'group' => 'core',
-    'name' => 'civicaseOverdueNotificationLimit',
+    'name' => 'civicaseCaseLastUpdatedNotificationLimit',
     'quick_form_type' => 'Element',
     'type' => 'Integer',
     'default' => 90,
@@ -14,7 +14,7 @@ return [
       'maxlength' => 4,
     ),
     'add' => '4.7',
-    'title' => 'Display Overdue notification after days',
+    'title' => 'Last updated notification after days',
     'is_domain' => 1,
     'is_contact' => 0,
     'description' => 'This adds a visual indicator for cases where there has not been any activity for the selected number of days. This will be visible on the Manage Cases screen on the last updated date.',

--- a/templates/CRM/Civicaseextra/Admin/Form/Settings.tpl
+++ b/templates/CRM/Civicaseextra/Admin/Form/Settings.tpl
@@ -1,6 +1,6 @@
 <tr class="crm-case-form-block-civicase-overdue-notification-limit">
-  <td class="label">{$form.civicaseOverdueNotificationLimit.label}</td>
-  <td>{$form.civicaseOverdueNotificationLimit.html}<br />
+  <td class="label">{$form.civicaseCaseLastUpdatedNotificationLimit.label}</td>
+  <td>{$form.civicaseCaseLastUpdatedNotificationLimit.html}<br />
     <span class="description">
       {ts}This adds a visual indicator for cases where there has not been any activity
       for the selected number of days. This will be visible on the Manage Cases screen


### PR DESCRIPTION
## Overview
As part of this PR, the civicase setting title for Visual Notification has been changed.


## Before
![2019-03-14 at 4 22 PM](https://user-images.githubusercontent.com/5058867/54351358-556f8280-4675-11e9-98cf-af3a0fd2f771.png)

## After
![2019-03-14 at 4 21 PM](https://user-images.githubusercontent.com/5058867/54351300-33760000-4675-11e9-8a46-91a2b5759540.png)

## Technical Details
Changed the setting name from `civicaseOverdueNotificationLimit` to `civicaseCaseLastUpdatedNotificationLimit`.
And changed the setting label in `settings/Civicaseextras.setting.php`