### PR TITLE
CGP-1475: Make Civicase Extension a dependency

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -24,4 +24,7 @@
   <civix>
     <namespace>CRM/Civicaseextras</namespace>
   </civix>
+  <requires>
+    <ext>uk.co.compucorp.civicase</ext>
+  </requires>
 </extension>


### PR DESCRIPTION
## Overview
This PR updates the info file so that the extension now requires `civicase` extension as a dependency.

We had an issue where some code implementation in Civicase caused an error because the civiextras extension was installed before civicase thereby throwing an error. This PR will prevent that from happening on any site again. The long term fix also is that the Civiase extras will be merged into Civicase soon.