### PR TITLE
NEUSPRT-343: Replace depreceated glob_recursive with alternative method in CiviCase

### DIFF
--- a/ang/civicaseextras.ang.php
+++ b/ang/civicaseextras.ang.php
@@ -1,15 +1,20 @@
 <?php
 
+use CRM_Civicase_Helper_GlobRecursive as GlobRecursive;
+
 /**
  * Returns a list of Civicaseextras JS files to be bundled.
  *
  * @return array
  */
 function getCivicaseExtrasJSFiles () {
-  return array_merge(array(
+  return array_merge([
     'assetBuilder://visual-bundle.js',
     'ang/civicaseextras.js'
-  ), glob_recursive(dirname(__FILE__) . '/civicaseextras/*.js'));
+  ], GlobRecursive::getRelativeToExtension(
+    'uk.co.compucorp.civicaseextras',
+    'ang/civicase-base/*.js'
+  ));
 }
 
 /**


### PR DESCRIPTION
## Overview 

The extension was causing a WSOD, and this is caused by the use of depreceated `glob_recursive` that is no longer available, in this PR we have replace this method with alternative method in CiviCase.