### PR TITLE
COMCL-794: Ensure last updated has visual changes as expected

### DIFF
--- a/ang/civicaseextras.ang.php
+++ b/ang/civicaseextras.ang.php
@@ -9,11 +9,11 @@ use CRM_Civicase_Helper_GlobRecursive as GlobRecursive;
  */
 function getCivicaseExtrasJSFiles () {
   return array_merge([
-    'assetBuilder://visual-bundle.js',
+    Civi::service('asset_builder')->getUrl('visual-bundle.js'),
     'ang/civicaseextras.js'
   ], GlobRecursive::getRelativeToExtension(
     'uk.co.compucorp.civicaseextras',
-    'ang/civicase-base/*.js'
+    'ang/civicaseextras/*.js'
   ));
 }
 
@@ -31,7 +31,7 @@ function getCivicaseExtrasSettings () {
 return [
   'js' => getCivicaseExtrasJSFiles(),
   'css' => [
-    'assetBuilder://visual-bundle.css',
+    Civi::service('asset_builder')->getUrl('visual-bundle.css'),
     'css/*.css',
   ],
   'partials' => [

--- a/civicaseextras.php
+++ b/civicaseextras.php
@@ -38,6 +38,9 @@ function civicaseextras_civicrm_enable() {
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_alterAngular/
  */
 function civicaseextras_civicrm_alterAngular(AngularManager $angular) {
+  $loader = Civi::service('angularjs.loader');
+  $loader->addModules(['civicaseextras']);
+
   _civicaseextras_alterAngular_addVisualAlert($angular);
   _civicaseextras_alterAngular_appendOutcomePanel($angular);
 }

--- a/templates/CRM/Civicaseextra/Admin/Form/Settings.tpl
+++ b/templates/CRM/Civicaseextra/Admin/Form/Settings.tpl
@@ -1,4 +1,4 @@
-<tr class="crm-case-form-block-civicase-overdue-notification-limit">
+{* <tr class="crm-case-form-block-civicase-overdue-notification-limit">
   <td class="label">{$form.civicaseCaseLastUpdatedNotificationLimit.label}</td>
   <td>{$form.civicaseCaseLastUpdatedNotificationLimit.html}<br />
     <span class="description">
@@ -7,4 +7,4 @@
       on the last updated date.{/ts}
     </span>
   </td>
-</tr>
+</tr> *}


### PR DESCRIPTION
## Overview
With this extension after updating the “Last updated notification after days“ field setting with X days, we expect the Last Updated date on Manage cases / Awards / Prospects to display dates older than the mentioned days in Red color. However, this is not working as the rows are not highlighted on CivICRM 5.75. This PR resolves this issue by ensuring the civicasextras angular module is always added to the Civicase dashboard page.

<img width="812" alt="Screenshot 2024-10-23 at 02 15 35" src="https://github.com/user-attachments/assets/74da0b06-e036-4073-997d-b687397e4003">

## Before
<img width="1260" alt="Screenshot 2024-10-23 at 02 17 50" src="https://github.com/user-attachments/assets/fdc76eee-2450-4bcb-99ee-12ca64447617">


## After
<img width="1261" alt="Screenshot 2024-10-23 at 02 15 23" src="https://github.com/user-attachments/assets/7243d65a-4019-47eb-b583-d627c86480d3">
